### PR TITLE
`_supported_by.erb` eu flag (small fix)

### DIFF
--- a/app/views/layouts/_supported_by.erb
+++ b/app/views/layouts/_supported_by.erb
@@ -7,7 +7,7 @@
       <% end %>
     <% end %>
 
-    <%- if I18n.exists?('footer.eu_funding_html') %>
+    <%- if I18n.exists?('footer.eu_funding_html') && I18n.t('footer.eu_funding_html').present? %>
       <div class="eu-notice">
         <%= image_tag('elixir/eu-flag.svg') %>
         <div>


### PR DESCRIPTION
**Summary of changes**

- In `app/views/layouts/_supported_by.erb`, I am adding whether `footer.eu_funding_html` is `present` or not

**Motivation and context**

I have in my `config/locales/overrides/custom.en.yml`, `footer.eu_funding_html: ''` and it still displayed the EU flag on the bottom of the screen.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
