### PR TITLE
Link to the code contributions documentation from developer page

### DIFF
--- a/app/views/about/developers.erb
+++ b/app/views/about/developers.erb
@@ -26,6 +26,8 @@
             <i class="fa fa-code about-icon motivation-box-graphic-small"></i>
             <p>
               Source code is available under the <%== t 'developer.code_license' %> license.
+              <br />We welcome your
+              <%== t 'developer.contributions' %>.
             </p>
           </div>
         </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -179,6 +179,8 @@ en:
       <a href="https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE", target="_blank">BSD 3-Clause<i class="icon icon-md arrow-top-right-icon"></i></a>
     data_license: >
       <a href="https://creativecommons.org/licenses/by/4.0/", target="_blank">CC-BY 4.0<i class="icon icon-md arrow-top-right-icon"></i></a>
+    contributions: >
+      <a href="https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md", target="_blank">contributions<i class="icon icon-md arrow-top-right-icon"></i></a>
     gmaps_countries: >
       'United Kingdom', 'Spain', 'Portugal', 'France', 'Belgium', 'Ireland', 'Estonia', 'Finland',
       'Germany', 'Austria', 'Italy', 'Hungary', 'Czech Republic', 'Estonia', 'Denmark',


### PR DESCRIPTION
**Summary of changes**

- Add a link to the contributions documentation from the About > Developer page.

**Motivation and context**

Raised in conversation with Carole, report that a student code contributor was struggling to find the relevant information. 
 
**Screenshots**

<img width="1491" height="912" alt="image" src="https://github.com/user-attachments/assets/0972dd1e-1bef-499c-9b69-366b46a903c8" />


**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
