### PR TITLE
Updated hints for events and materials

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -597,7 +597,7 @@ en:
       description: 'Provide a textual description of the training event, for additional context.'
       visible: 'Whether this event should be shown or hidden from the events page.'
       duration: 'In hours and minutes (HH:MM), how long will your training event run?'
-      eligibility: 'Options for registration. To be chosen from one of the three: First come first served, Registration of Interest, By invitation.'
+      eligibility: 'Who can attend the training event?'
       end: 'When does the event end?'
       event_type: 'Select the most appropriate event type for the training event.'
       fields: 'Select Fields of Research to better classify your event.'


### PR DESCRIPTION
**Summary of changes**

- As described in docs issue 8 https://github.com/ElixirTeSS/docs/issues/8 some of the events and materials hints can be updated and expanded, aligned to the new docs. 
- Does not include a few materials hints to return to in the future:
  - Scientific Topics / Keywords (maybe these labels are missing?)
  - Target Audience
  - Competency Levels


**Motivation and context**

- Follows feedback from the Flemish RDM group testing Spaces.
 

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
