### PR TITLE
Use "services" in GitHub actions

### DIFF
--- a/.github/workflows/deployment-checks.yml
+++ b/.github/workflows/deployment-checks.yml
@@ -12,17 +12,32 @@ jobs:
       DB_PASSWORD: password
       SECRET_BASE_KEY: test_key
       RAILS_ENV: production
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_DB: ${{ env.DB_NAME }}
+          POSTGRES_USER: ${{ env.DB_USER }}
+          POSTGRES_PASSWORD: ${{ env.DB_PASSWORD }}
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
     steps:
-      - uses: harmon758/postgresql-action@v1
-        with:
-          postgresql db: ${DB_NAME}
-          postgresql user: ${DB_USER}
-          postgresql password: ${DB_PASSWORD}
-        name: Set up database
-
       - uses: actions/checkout@v4
         name: Set up Ruby
-
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       REDIS_TEST_URL: redis://localhost:6379/0
     services:
       postgres:
-        image: postgres:14
+        image: postgres
         env:
           POSTGRES_DB: ${{ env.DB_NAME }}
           POSTGRES_USER: ${{ env.DB_USER }}


### PR DESCRIPTION
**Summary of changes**

- Replace custom actions that run Postgres & Redis with GitHub's own [containerized services](https://docs.github.com/en/actions/tutorials/use-containerized-services).

**Motivation and context**

Action run failed due to rate limit hit: https://github.com/ElixirTeSS/TeSS/actions/runs/20440274417/job/58731372004#step:5:18

> docker: Error response from daemon: toomanyrequests: You have reached your unauthenticated pull rate limit. https://www.docker.com/increase-rate-limit.

and possibly GitHub does some caching/mirroring when you use its built-in services that could avoid this...?

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
