### PR TITLE
Add ELIXIR LP editorial message from Issue 1200

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -400,6 +400,16 @@ en:
         <p>Governance: Maintaining the learning path</p>
         <ol><li>It is the responsibility of the learning path curator to maintain their community's learning paths.</li>
         <li>The curator can assign collaborators to work on each learning path, depending on the expertise required.</li></ol>
+        <h4>Creating ELIXIR Learning Paths</h4>
+        <p>If you would like to create an ELIXIR Learning Path, 
+        <a href='https://docs.google.com/forms/d/e/1FAIpQLSeZcoZyxsDpneV7fidqXhKCPeKuQe9fW8eZkl7geyQ2oU7q-A/viewform?usp=sharing&ouid=108152593873011990548'
+        target='_blank'>please complete this form</a>. 
+        ELIXIR Learning Paths follow a Standard Operating Procedure (SOP) to ensure quality, consistency, and long-term 
+        sustainability. 
+        <a href='https://docs.google.com/document/d/10IwJeTXViT1wNHMyfNhUQhSD1p1NCWdOj_Q6sw_SAWk/edit?usp=sharing' 
+        target='_blank'>Further details about the process are available here</a>.<p>
+        <p>After you submit the form, a member of the ELIXIR Learning Paths Editorial Board will contact you to discuss 
+        your proposal and outline the next steps.</p>
       overview: >
         <p>To register a learning path you need to follow the three steps described below:</p>
         <ol><li>Register Training Materials</li>


### PR DESCRIPTION
**Summary of changes**

- Include the ELIXIR learning paths editorial instructions and links to the [About pages](https://tess.elixir-europe.org/learning_paths/new).
- Added to the `en : register : learning_paths : editorial field`. 
- I don't know how to add to the [LP>New page](https://tess.elixir-europe.org/learning_paths/new) side bar. I have written text there but I don't know how to add links. 
- I am also adding to the new TeSS Docs (separate repo).

**Motivation and context**

- Requested in #1200 by the Learning Paths Focus Group.
 
**Screenshots**

<img width="1605" height="977" alt="image" src="https://github.com/user-attachments/assets/6848ab10-e2ab-4dbe-b978-8c06c771d21c" />

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
