### PR TITLE
Fix "see here..." links in info boxes.

### DIFF
--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -5,8 +5,8 @@ require 'rss'
 module EventsHelper
   def events_info
     I18n.t('info.events.description',
-           link: link_to(I18n.t('info.events.link'),
-                         registering_resources_path(anchor: 'automatic')))
+           link: I18n.t('info.events.link'),
+           url: registering_resources_path(anchor: 'automatic'))
   end
 
   def google_calendar_export_url(event)

--- a/app/helpers/learning_paths_helper.rb
+++ b/app/helpers/learning_paths_helper.rb
@@ -4,4 +4,16 @@ module LearningPathsHelper
     { lp: [topic_link, topic_item].map(&:id).join(':') }
   end
 
+  def learning_paths_info
+    I18n.t('info.learning_paths.description',
+           link: I18n.t('info.learning_paths.link'),
+           url: registering_learning_paths_path(anchor: 'register_paths'))
+  end
+
+  def learning_path_topics_info
+    I18n.t('info.learning_path_topics.description',
+           link: I18n.t('info.learning_path_topics.link'),
+           url: registering_learning_paths_path(anchor: 'topics'))
+  end
+
 end

--- a/app/helpers/materials_helper.rb
+++ b/app/helpers/materials_helper.rb
@@ -2,30 +2,18 @@
 module MaterialsHelper
   def materials_info
     I18n.t('info.materials.description',
-           link: link_to(I18n.t('info.materials.link'),
-                         registering_resources_path(anchor: 'automatic')))
+           link: I18n.t('info.materials.link'),
+           url: registering_resources_path(anchor: 'automatic'))
   end
 
   def elearning_materials_info
     I18n.t('info.elearning_materials.description',
-           link: link_to(I18n.t('info.elearning_materials.link'),
-                         registering_resources_path(anchor: 'automatic')))
+           link: I18n.t('info.elearning_materials.link'),
+           url: registering_resources_path(anchor: 'automatic'))
   end
 
   def topics_info
     I18n.t('info.topics.description')
-  end
-
-  def learning_paths_info
-    I18n.t('info.learning_paths.description',
-           link: link_to(I18n.t('info.learning_paths.link'),
-                         registering_learning_paths_path(anchor: 'register_paths')))
-  end
-
-  def learning_path_topics_info
-    I18n.t('info.learning_path_topics.description',
-           link: link_to(I18n.t('info.learning_path_topics.link'),
-                         registering_learning_paths_path(anchor: 'topics')))
   end
 
   # Returns an array of two-element arrays of licences ready to be used in options_for_select() for generating option/select tags

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1058,19 +1058,19 @@ en:
       description: |
         An event in %{site_name} is a link to a single training event sourced by a provider along with description and other meta information (e.g. date, location, audience, ontological categorization, keywords, etc.).<br>
         Training events can be added manually or automatically harvested from a provider's website.<br>
-        If your website contains training events that you wish to include in %{site_name}, %{link}.
-      link : see here for details on automatic registration
+        If your website contains training events that you wish to include in %{site_name}, [%{link}](%{url}).
+      link: see here for details on automatic registration
     materials:
       description: |
         In the context of %{site_name}, a training material is a link to a single online training material sourced by a content provider (such as a text on a Web page, presentation, video, etc.).<br>
         Materials can be added manually or automatically harvested from a provider's website.<br>
-        If your website contains training materials that you wish to include in %{site_name}, %{link}.
-      link : see here for details on automatic registration
+        If your website contains training materials that you wish to include in %{site_name}, [%{link}](%{url}).
+      link: see here for details on automatic registration
     elearning_materials:
       description: |
         e-Learning materials are curated materials focused on e-Learning.
-        If your website contains e-Learning materials that you wish to include in %{site_name}, %{link}.
-      link : see here for details on automatic registration
+        If your website contains e-Learning materials that you wish to include in %{site_name}, [%{link}](%{url}).
+      link: see here for details on automatic registration
     topics:
       description: |
         %{site_name} generates a scientific topic suggestion for each resource registered. It does this by passing the description and title of the resource to the Bioportal Annotator Web service.
@@ -1084,8 +1084,8 @@ en:
         1. Register training materials.
         2. Create a learning path topic and add materials to it (repeat for each topic).
         3. Register a learning path and add learning path topics to it.<br>
-        %{link}.
-      link : See here for details on learning paths
+        [%{link}](%{url}).
+      link: See here for details on learning paths
     learning_path_topics:
       description: |
         A learning path topic is an ordered list of training materials.
@@ -1094,8 +1094,8 @@ en:
         1. Register training materials.
         2. Create a learning path topic and add materials to it (repeat for each topic).
         3. Register a learning path and add learning path topics to it.<br>
-        %{link}
-      link : See here for details on learning path topics
+        [%{link}](%{url})
+      link: See here for details on learning path topics
     trainers:
       description: |
         %{site_name} provides a facility that allows registered users to provide information about their training experience and make this publicly available via the Trainers Register.


### PR DESCRIPTION
**Summary of changes**

- Changes the links in the various info boxes to markdown equivalents.

**Motivation and context**

The info boxes are rendered as markdown (for some reason), and the HTML was being filtered out

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
