### PR TITLE
[`process_array`]: added a regex to cover most separators

### DIFF
--- a/lib/ingestors/csv_ingestion.rb
+++ b/lib/ingestors/csv_ingestion.rb
@@ -15,7 +15,11 @@ module Ingestors
     end
 
     def process_array(row, header)
-      row[header].to_s.lstrip.split(/;/).reject(&:empty?).compact unless row[header].nil?
+      # split by: comma or semicolon, optionally surrounded by whitespace
+      # or two or more whitespace characters
+      # any number of newline characters
+      split_regex = /\s*[,;]\s*|\s{2,}|[\r\n]+/x
+      row[header].to_s.lstrip.split(split_regex).reject(&:empty?).compact unless row[header].nil?
     end
 
     def get_column(row, header)


### PR DESCRIPTION
**Summary of changes**

- `lib/ingestors/csv_ingestion.rb`: added a `split_regex` to cover most separators available in .csv files

**Motivation and context**

- When ingesting from a google sheet, it appears that keywords, authors and contributors were *not separated*
- This came from the feedback of David Chamont (EVERSE)
 
**Screenshots**

Left: current branch (separating keywords and authors), right: prod (big keyword, one big author)

<img width="1512" height="374" alt="image" src="https://github.com/user-attachments/assets/62f0f59b-d911-46f0-adca-236fe86a0517" />

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
