### PR TITLE
controlled vocabulary option for target audience

### DIFF
--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -105,7 +105,15 @@
   <% end %>
 
   <!-- Field: Target Audience -->
-  <%= f.multi_input :target_audience, errors: @event.errors[:target_audience], title: t('events.hints.targets') %>
+  <% if TeSS::Config.feature['controlled_vocabulary_vars'].include? 'target_audience' %>
+    <%= f.dropdown :target_audience,
+                  options: TargetAudienceDictionary.instance.options_for_select,
+                  label: 'Target Audience',
+                  errors: @event.errors[:target_audience],
+                  title: t('events.hints.targets') %>
+  <% else %>
+    <%= f.multi_input :target_audience, errors: @event.errors[:target_audience], title: t('events.hints.targets') %>
+  <% end %>
 
   <!-- Field: Topics -->
   <% if !TeSS::Config.feature['disabled'].include? 'topics' %>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -108,7 +108,7 @@
   <% if TeSS::Config.feature['controlled_vocabulary_vars'].include? 'target_audience' %>
     <%= f.dropdown :target_audience,
                   options: TargetAudienceDictionary.instance.options_for_select,
-                  label: 'Target Audience',
+                  label: 'Target audiences',
                   errors: @event.errors[:target_audience],
                   title: t('events.hints.targets') %>
   <% else %>

--- a/app/views/materials/_form.html.erb
+++ b/app/views/materials/_form.html.erb
@@ -79,7 +79,7 @@
   <% if TeSS::Config.feature['controlled_vocabulary_vars'].include? 'target_audience' %>
     <%= f.dropdown :target_audience,
                   options: TargetAudienceDictionary.instance.options_for_select,
-                  label: 'Target Audience',
+                  label: 'Target audiences',
                   errors: @material.errors[:target_audience],
                   title: t('events.hints.targets'),
                   visibility_toggle: TeSS::Config.feature['materials_disabled'] %>

--- a/app/views/materials/_form.html.erb
+++ b/app/views/materials/_form.html.erb
@@ -76,8 +76,17 @@
                     visibility_toggle: TeSS::Config.feature['materials_disabled'] %>
 
   <!-- Field: Target Audience -->
-  <%= f.multi_input :target_audience, label: 'Target audiences', errors: @material.errors[:target_audience],
-                    title: t('events.hints.targets'), visibility_toggle: TeSS::Config.feature['materials_disabled'] %>
+  <% if TeSS::Config.feature['controlled_vocabulary_vars'].include? 'target_audience' %>
+    <%= f.dropdown :target_audience,
+                  options: TargetAudienceDictionary.instance.options_for_select,
+                  label: 'Target Audience',
+                  errors: @material.errors[:target_audience],
+                  title: t('events.hints.targets'),
+                  visibility_toggle: TeSS::Config.feature['materials_disabled'] %>
+  <% else %>
+    <%= f.multi_input :target_audience, label: 'Target audiences', errors: @material.errors[:target_audience],
+                      title: t('events.hints.targets'), visibility_toggle: TeSS::Config.feature['materials_disabled'] %>
+  <% end %>
 
   <!-- Field: Prerequisites -->
   <%= f.input :prerequisites, as: :markdown_area, field_lock: true,

--- a/config/tess.example.yml
+++ b/config/tess.example.yml
@@ -166,6 +166,7 @@ default: &default
     bioschemas_testing: false
     collection_curation: true
     auto_parse_vars: [] # available features to auto parse from description: ['keywords', 'target_audience']
+    controlled_vocabulary_vars: [] # available features: ['target audience']
 
     # User login
     invitation: false

--- a/config/tess.example.yml
+++ b/config/tess.example.yml
@@ -166,7 +166,7 @@ default: &default
     bioschemas_testing: false
     collection_curation: true
     auto_parse_vars: [] # available features to auto parse from description: ['keywords', 'target_audience']
-    controlled_vocabulary_vars: [] # available features: ['target audience']
+    controlled_vocabulary_vars: [] # available features: ['target_audience']
 
     # User login
     invitation: false


### PR DESCRIPTION
**Summary of changes**
Config option to have target_audience field in events and materials use the available dictionary as options with a dropdown instead of the free string input field

**Motivation and context**

Easier for searching and filtering

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree to license it to the TeSS codebase under the [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
