### PR TITLE
Ensure expandable sections always expand fully

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -292,7 +292,7 @@ document.addEventListener("turbolinks:load", function(e) {
                 return true;
             }
             this.dataset.origHeight = this.clientHeight;
-            this.style.maxHeight = '' + limit + 'px';
+            this.style.maxHeight = '' + (limit - 50) + 'px';
             this.classList.add('tess-expandable-closed');
             const btn = $('<a href="#" class="tess-expandable-btn">Show more</a>');
             btn.insertAfter($(this));
@@ -379,13 +379,14 @@ $(document).on('click', '.tess-expandable-btn', function (event) {
         return false;
     }
 
-    const maxHeight = parseInt(div.dataset.origHeight) + 80;
+    const maxHeight = parseInt(div.dataset.origHeight) + 120;
     const limit = parseInt(div.dataset.heightLimit || "300");
 
     if (div.classList.contains('tess-expandable-closed')) {
         div.classList.add('tess-expandable-open');
         div.classList.remove('tess-expandable-closed');
         div.style.maxHeight = '' + maxHeight + 'px';
+        setTimeout(() => div.style.maxHeight = null, 500);
         this.innerHTML = 'Show less';
     } else {
         div.classList.remove('tess-expandable-open');


### PR DESCRIPTION
**Summary of changes**

- Remove `maxHeight` from expandable content after animation, allowing it to reach full size if it hasn't already done so.

**Motivation and context**

In some cases, the sections were not fully expanded after clicking "Show more": #1215

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree to license it to the TeSS codebase under the [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
