### PR TITLE
Fix 500 error when a person is linked to a non-trainer profile

### DIFF
--- a/app/helpers/materials_helper.rb
+++ b/app/helpers/materials_helper.rb
@@ -105,7 +105,8 @@ module MaterialsHelper
     display_attribute(resource, attribute) do |values|
       html = values.map do |person|
         if person.profile
-          link_to(person.profile.full_name, person.profile)
+          target = person.profile.is_a?(Trainer) ? person.profile : person.profile.user
+          link_to(person.profile.full_name, target)
         elsif person.orcid.present?
           image_tag('ORCID-iD_icon_vector.svg', size: 16) + ' ' +
           external_link(person.display_name, person.orcid_url)

--- a/test/controllers/materials_controller_test.rb
+++ b/test/controllers/materials_controller_test.rb
@@ -1629,6 +1629,28 @@ class MaterialsControllerTest < ActionController::TestCase
     end
   end
 
+  test 'should display non-trainer author with linked ORCID' do
+    jc = profiles(:trainer_one_profile)
+    jc.update_column(:public, false)
+    jc.update_column(:type, 'Profile')
+    assert @material.update(authors: [{ name: 'John Doe' },
+                                      { name: 'Jane Smith', orcid: '0000-0001-9999-9990' }],
+                            contributors: [{ name: 'Jos Ca', orcid: '0000-0002-1825-0097' }])
+
+    get :show, params: { id: @material.id }
+
+    assert_select '.authors', text: 'Authors: John Doe, Jane Smith'
+    assert_select '.authors a', count: 1 do
+      assert_select '[href=?]', 'https://orcid.org/0000-0001-9999-9990'
+    end
+
+    assert_select '.contributors', { text: 'Contributors: Josiah Carberry' },
+                  "Should use name from person's profile, if linked"
+    assert_select '.contributors a', count: 1 do
+      assert_select '[href=?]', user_path(jc.user)
+    end
+  end
+
   test 'should update material authors using structured authors' do
     sign_in @material.user
     update = @updated_material.merge(authors: [

--- a/test/controllers/materials_controller_test.rb
+++ b/test/controllers/materials_controller_test.rb
@@ -1631,7 +1631,7 @@ class MaterialsControllerTest < ActionController::TestCase
 
   test 'should display non-trainer contributor with linked ORCID' do
     jc = profiles(:trainer_one_profile)
-    jc.update!(public: false)
+    jc.update!(public: false, website: nil, image_url: nil)
     jc = Profile.find(jc.id)
     assert @material.update(authors: [{ name: 'John Doe' },
                                       { name: 'Jane Smith', orcid: '0000-0001-9999-9990' }],

--- a/test/controllers/materials_controller_test.rb
+++ b/test/controllers/materials_controller_test.rb
@@ -1629,10 +1629,10 @@ class MaterialsControllerTest < ActionController::TestCase
     end
   end
 
-  test 'should display non-trainer author with linked ORCID' do
+  test 'should display non-trainer contributor with linked ORCID' do
     jc = profiles(:trainer_one_profile)
-    jc.update_column(:public, false)
-    jc.update_column(:type, 'Profile')
+    jc.update!(public: false)
+    jc = Profile.find(jc.id)
     assert @material.update(authors: [{ name: 'John Doe' },
                                       { name: 'Jane Smith', orcid: '0000-0001-9999-9990' }],
                             contributors: [{ name: 'Jos Ca', orcid: '0000-0002-1825-0097' }])


### PR DESCRIPTION
**Summary of changes**

- Changes the link target to point to the `/users/` path for non-trainer author/contributors.

**Motivation and context**

#1280

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree to license it to the TeSS codebase under the [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
