### PR TITLE
Avoid empty update logs

### DIFF
--- a/lib/ingestors/ingestor.rb
+++ b/lib/ingestors/ingestor.rb
@@ -213,7 +213,14 @@ module Ingestors
               method: source.method
             }
           end
-          resource.create_activity(update ? :update : :create, owner: user, parameters: activity_params)
+
+          if update
+            if resource.log_update_activity?
+              resource.create_activity(:update, owner: user, parameters: activity_params)
+            end
+          else
+            resource.create_activity(:create, owner: user, parameters: activity_params)
+          end
           @stats[key][update ? :updated : :added] += 1
         else
           @stats[key][:rejected] += 1

--- a/test/unit/ingestors/ingestor_test.rb
+++ b/test/unit/ingestors/ingestor_test.rb
@@ -392,4 +392,40 @@ class IngestorTest < ActiveSupport::TestCase
     end
   end
 
+  test 'does not log useless update activities' do
+    user = users(:scraper_user)
+    provider = content_providers(:goblet)
+    url = 'http://example.com/cool-course-summer'
+
+    assert provider.events.where(url: url).any?
+    event = OpenStruct.new(url: 'http://example.com/cool-course-summer',
+                           title: 'Summer Course on Learning Stuff')
+
+    ingestor = Ingestors::Ingestor.new
+    ingestor.instance_variable_set(:@events, [event])
+
+    assert_no_difference('provider.events.count') do
+      assert_no_difference('PublicActivity::Activity.where(key: "event.create").count') do
+        assert_difference('PublicActivity::Activity.where(key: "event.update").count', 1) do
+          assert_difference('PublicActivity::Activity.where(key: "event.update_parameter").count', 2) do # Title and slug are updated
+            ingestor.write(user, provider)
+          end
+        end
+      end
+    end
+
+    ingestor = Ingestors::Ingestor.new
+    ingestor.instance_variable_set(:@events, [event])
+
+    assert_no_difference('provider.events.count') do
+      assert_no_difference('PublicActivity::Activity.where(key: "event.create").count') do
+        assert_no_difference('PublicActivity::Activity.where(key: "event.update").count') do
+          assert_no_difference('PublicActivity::Activity.where(key: "event.update_parameter").count') do
+            ingestor.write(user, provider) # Nothing changed so don't log
+          end
+        end
+      end
+    end
+  end
+
 end

--- a/test/unit/ingestors/ingestor_test.rb
+++ b/test/unit/ingestors/ingestor_test.rb
@@ -396,18 +396,19 @@ class IngestorTest < ActiveSupport::TestCase
     user = users(:scraper_user)
     provider = content_providers(:goblet)
     url = 'http://example.com/cool-course-summer'
+    e = events(:course_event)
+    e.update!(scraper_record: true)
 
     assert provider.events.where(url: url).any?
-    event = OpenStruct.new(url: 'http://example.com/cool-course-summer',
-                           title: 'Summer Course on Learning Stuff')
+
+    event = OpenStruct.new(url: 'http://example.com/cool-course-summer', title: 'A different title')
 
     ingestor = Ingestors::Ingestor.new
     ingestor.instance_variable_set(:@events, [event])
-
     assert_no_difference('provider.events.count') do
       assert_no_difference('PublicActivity::Activity.where(key: "event.create").count') do
         assert_difference('PublicActivity::Activity.where(key: "event.update").count', 1) do
-          assert_difference('PublicActivity::Activity.where(key: "event.update_parameter").count', 2) do # Title and slug are updated
+          assert_difference('PublicActivity::Activity.where(key: "event.update_parameter").count', 1) do # Title is changed
             ingestor.write(user, provider)
           end
         end
@@ -416,7 +417,6 @@ class IngestorTest < ActiveSupport::TestCase
 
     ingestor = Ingestors::Ingestor.new
     ingestor.instance_variable_set(:@events, [event])
-
     assert_no_difference('provider.events.count') do
       assert_no_difference('PublicActivity::Activity.where(key: "event.create").count') do
         assert_no_difference('PublicActivity::Activity.where(key: "event.update").count') do


### PR DESCRIPTION
**Summary of changes**

- When scraping, do not record an update log if no fields were changed

**Motivation and context**

#1279

Brings behaviour inline with manual updates.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree to license it to the TeSS codebase under the [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
