### PR TITLE
Display competency level more consistently

### DIFF
--- a/app/helpers/materials_helper.rb
+++ b/app/helpers/materials_helper.rb
@@ -50,8 +50,7 @@ module MaterialsHelper
     TargetAudienceDictionary.instance.lookup_value(label, 'title') || label
   end
 
-  def display_difficulty_level(resource)
-    value = resource.send('difficulty_level')
+  def display_difficulty_level(value)
     if value == 'beginner'
       '• ' + value
     elsif value == 'intermediate'

--- a/app/helpers/materials_helper.rb
+++ b/app/helpers/materials_helper.rb
@@ -51,15 +51,19 @@ module MaterialsHelper
   end
 
   def display_difficulty_level(value)
+    data = DifficultyDictionary.instance.lookup(value)
+    return nil if data.nil? || value == 'notspecified'
     if value == 'beginner'
-      '• ' + value
+      text = '• ' + data['title']
     elsif value == 'intermediate'
-      '•• ' + value
+      text = '•• ' + data['title']
     elsif value == 'advanced'
-      '••• ' + value
+      text = '••• ' + data['title']
     else
-      ''
+      text = data['title']
     end
+
+    content_tag(:span, text, title: data['description'])
   end
 
   def display_attribute(resource, attribute, show_label: true, title: nil, markdown: false, list: false, expandable: false)

--- a/app/views/common/_extra_metadata.html.erb
+++ b/app/views/common/_extra_metadata.html.erb
@@ -4,6 +4,7 @@
 <%= display_attribute(resource, :licence) { |value| licence_name_for_abbreviation(value) } if resource.respond_to?(:licence) %>
 <%= display_attribute(resource, :contact) if resource.respond_to?(:contact) %>
 <%= display_attribute(resource, :keywords) { |values| values.join(', ') } %>
+<%= display_attribute(resource, :difficulty_level) { |value| display_difficulty_level(value) } if resource.respond_to?(:difficulty_level) %>
 
 <% if resource.is_a?(Material) %>
   <%= display_attribute(resource, :fields) { |values| values.join(', ') } %>

--- a/app/views/learning_path_topics/_form.html.erb
+++ b/app/views/learning_path_topics/_form.html.erb
@@ -10,7 +10,7 @@
 
     <!-- Field: Level -->
     <%= f.input :difficulty_level, collection: DifficultyDictionary.instance.options_for_select,
-                label: 'Competency level', prompt: 'Select a difficulty level...',
+                prompt: 'Select a difficulty level...',
                 errors: @learning_path_topic.errors[:difficulty_level], input_html: { title: t('learning_paths.hints.difficulty') } %>
 
 

--- a/app/views/learning_path_topics/_learning_path_topic.html.erb
+++ b/app/views/learning_path_topics/_learning_path_topic.html.erb
@@ -1,11 +1,16 @@
 <li class="masonry-brick media-item long">
   <%= link_to learning_path_topic, class: 'link-overlay' do %>
-    <h4><%= learning_path_topic.title %></h4>
+    <div class="masonry-brick-heading">
+        <h4><%= learning_path_topic.title %></h4>
+    </div>
 
-    <% competency = display_difficulty_level(learning_path_topic.difficulty_level) %>
-    <% if competency.present? %>
-      <div class="font-size-lg"><%= competency %></div>
-    <% end %>
+    <div class="mb-3">
+      <% competency = display_difficulty_level(learning_path_topic.difficulty_level) %>
+      <% if competency %>
+        <span class="label label-default"><%= competency %></span>
+      <% end %>
+      <span class="label label-default"><i class="fa fa-book"></i> <%= pluralize(learning_path_topic.materials.count, 'materials') %></span>
+    </div>
 
     <div class="markdown-description">
       <%= render_sanitized_markdown truncate(learning_path_topic.description, length: 300, separator: ' ') %>

--- a/app/views/learning_path_topics/_learning_path_topic.html.erb
+++ b/app/views/learning_path_topics/_learning_path_topic.html.erb
@@ -2,8 +2,9 @@
   <%= link_to learning_path_topic, class: 'link-overlay' do %>
     <h4><%= learning_path_topic.title %></h4>
 
-    <% if learning_path_topic.difficulty_level.present? %>
-      <div class="font-size-lg"><%= display_difficulty_level(learning_path_topic.difficulty_level) %></div>
+    <% competency = display_difficulty_level(learning_path_topic.difficulty_level) %>
+    <% if competency.present? %>
+      <div class="font-size-lg"><%= competency %></div>
     <% end %>
 
     <div class="markdown-description">

--- a/app/views/learning_path_topics/_learning_path_topic.html.erb
+++ b/app/views/learning_path_topics/_learning_path_topic.html.erb
@@ -2,6 +2,10 @@
   <%= link_to learning_path_topic, class: 'link-overlay' do %>
     <h4><%= learning_path_topic.title %></h4>
 
+    <% if learning_path_topic.difficulty_level.present? %>
+      <div class="font-size-lg"><%= display_difficulty_level(learning_path_topic.difficulty_level) %></div>
+    <% end %>
+
     <div class="markdown-description">
       <%= render_sanitized_markdown truncate(learning_path_topic.description, length: 300, separator: ' ') %>
     </div>

--- a/app/views/learning_path_topics/show.html.erb
+++ b/app/views/learning_path_topics/show.html.erb
@@ -21,10 +21,11 @@
     </div>
     <h4 class="nav-heading"><%= LearningPathTopic.human_attribute_name(:difficulty_level) %></h4>
     <div class="nav-block">
-      <% if @learning_path_topic.difficulty_level.present? %>
-        <span class="label label-default"><%= display_difficulty_level(@learning_path_topic.difficulty_level) %></span>
+      <% competency = display_difficulty_level(@learning_path_topic.difficulty_level) %>
+      <% if competency.present? %>
+        <span class="label label-default"><%= competency %></span>
       <% else %>
-        <span class="empty">None</span>
+        <span class="empty">Not specified</span>
       <% end %>
     </div>
     <h4 class="nav-heading"><%= LearningPathTopic.human_attribute_name(:owner) %></h4>

--- a/app/views/learning_path_topics/show.html.erb
+++ b/app/views/learning_path_topics/show.html.erb
@@ -1,6 +1,6 @@
 <div class="wrapper collapsing-wrapper">
   <div class="collapsing-sidebar" id="sidebar">
-    <h4 class="nav-heading">Topic</h4>
+    <h4 class="nav-heading"><%= LearningPathTopic.model_name.human %></h4>
     <div class="nav-block">
       <h5>
         <%= @learning_path_topic.title %>
@@ -11,7 +11,7 @@
         </div>
       <% end %>
     </div>
-    <h4 class="nav-heading">Keywords</h4>
+    <h4 class="nav-heading"><%= LearningPathTopic.human_attribute_name(:keywords) %></h4>
     <div class="nav-block">
       <% if @learning_path_topic.keywords.any? %>
         <%= @learning_path_topic.keywords.join(', ') %>
@@ -19,7 +19,15 @@
         <span class="empty">None</span>
       <% end %>
     </div>
-    <h4 class="nav-heading">Owner</h4>
+    <h4 class="nav-heading"><%= LearningPathTopic.human_attribute_name(:difficulty_level) %></h4>
+    <div class="nav-block">
+      <% if @learning_path_topic.difficulty_level.present? %>
+        <span class="label label-default"><%= display_difficulty_level(@learning_path_topic.difficulty_level) %></span>
+      <% else %>
+        <span class="empty">None</span>
+      <% end %>
+    </div>
+    <h4 class="nav-heading"><%= LearningPathTopic.human_attribute_name(:owner) %></h4>
     <div class="nav-block">
       <%= link_to @learning_path_topic.user.name, @learning_path_topic.user %>
     </div>

--- a/app/views/learning_paths/_form.html.erb
+++ b/app/views/learning_paths/_form.html.erb
@@ -55,6 +55,12 @@
   <%= f.multi_input :target_audience, label: 'Target audiences', errors: @learning_path.errors[:target_audience],
                     title: t('events.hints.targets'), visibility_toggle: TeSS::Config.feature['learning_paths_disabled'] %>
 
+  <!-- Field: Level -->
+  <%= f.input :difficulty_level, collection: DifficultyDictionary.instance.options_for_select,
+              prompt: 'Select a difficulty level...',
+              errors: @learning_path.errors[:difficulty_level], input_html: { title: t('learning_paths.hints.difficulty') },
+              visibility_toggle: TeSS::Config.feature['learning_paths_disabled'] %>
+
   <!-- Field: Prerequisites -->
   <%= f.input :prerequisites, as: :markdown_area,
               input_html: { rows: '3', title: t('learning_paths.hints.prerequisites') },

--- a/app/views/learning_paths/_learning_path.html.erb
+++ b/app/views/learning_paths/_learning_path.html.erb
@@ -1,42 +1,47 @@
-<li class="masonry-brick media-item large block-item learning-path-bg-<%= (learning_path.id % 4) + 1 -%>">
-  <%= link_to learning_path, class: 'link-overlay' do %>
-    <%= item_order_badge(collection_item) if defined? collection_item %>
+<% cache(learning_path, expires_in: 1.hour) do %>
+  <li class="masonry-brick media-item large block-item learning-path-bg-<%= (learning_path.id % 4) + 1 -%>">
+    <%= link_to learning_path, class: 'link-overlay' do %>
+      <%= item_order_badge(collection_item) if defined? collection_item %>
 
-    <div class="masonry-brick-heading">
-      <div class="masonry-icons">
-        <% if current_user&.is_admin? %>
-          <%= missing_icon(learning_path) %>
-          <%= scrape_status_icon(learning_path) %>
-          <%= suggestion_icon(learning_path) %>
-        <% end %>
-      </div>
-      <div class="sub-heading">
-        <%= display_attribute_no_label(learning_path, :learning_path_type) %>
-      </div>
-      <h4 class="mb-3"><%= learning_path.title %></h4>
-    </div>
+      <div class="masonry-brick-heading">
+        <div class="masonry-icons">
+          <% if current_user&.is_admin? %>
+            <%= missing_icon(learning_path) %>
+            <%= scrape_status_icon(learning_path) %>
+            <%= suggestion_icon(learning_path) %>
+          <% end %>
+        </div>
+        <div class="sub-heading">
+          <%= display_attribute_no_label(learning_path, :learning_path_type) %>
+        </div>
+        <h4 class="mb-3"><%= learning_path.title %></h4>
+        <%= rand %>
 
-    <div class="clearfix">
-      <div class="pull-right">
-        <% if controller_name != 'content_providers' && learning_path.content_provider %>
-          <%= image_tag(learning_path.content_provider.image.url, class: 'provider-avatar') %>
-        <% end %>
       </div>
 
-      <div>
-        <% competency = display_difficulty_level(learning_path.difficulty_level) %>
-        <% if competency %>
-          <span class="label label-default"><%= competency %></span>
-        <% end %>
-        <span class="label label-default"><i class="fa fa-folder-open"></i> <%= pluralize(learning_path.topics.count, 'topic') %></span>
-        <span class="label label-default"><i class="fa fa-book"></i> <%= pluralize(learning_path.topics_materials.count, 'materials') %></span>
+      <div class="clearfix">
+        <div class="pull-right">
+          <% if controller_name != 'content_providers' && learning_path.content_provider %>
+            <%= image_tag(learning_path.content_provider.image.url, class: 'provider-avatar') %>
+          <% end %>
+        </div>
+
+        <div>
+          <% competency = display_difficulty_level(learning_path.difficulty_level) %>
+          <% if competency %>
+            <span class="label label-default"><%= competency %></span>
+          <% end %>
+          <span class="label label-default"><i class="fa fa-folder-open"></i> <%= pluralize(learning_path.topics.count, 'topic') %></span>
+          <span class="label label-default"><i class="fa fa-book"></i> <%= pluralize(learning_path.topics_materials.count, 'materials') %></span>
+        </div>
+
+        <div>
+          <%= keywords_and_topics(learning_path, limit: 10) %>
+        </div>
       </div>
 
-      <div>
-        <%= keywords_and_topics(learning_path, limit: 10) %>
-      </div>
-    </div>
+      <%= item_comment(collection_item) if defined? collection_item %>
+    <% end %>
+  </li>
+<% end %>
 
-    <%= item_comment(collection_item) if defined? collection_item %>
-  <% end %>
-</li>

--- a/app/views/learning_paths/_learning_path.html.erb
+++ b/app/views/learning_paths/_learning_path.html.erb
@@ -24,6 +24,10 @@
       </div>
 
       <div>
+        <% competency = display_difficulty_level(learning_path.difficulty_level) %>
+        <% if competency %>
+          <span class="label label-default"><%= competency %></span>
+        <% end %>
         <span class="label label-default"><i class="fa fa-folder-open"></i> <%= pluralize(learning_path.topics.count, 'topic') %></span>
         <span class="label label-default"><i class="fa fa-book"></i> <%= pluralize(learning_path.topics_materials.count, 'materials') %></span>
       </div>

--- a/app/views/learning_paths/show.html.erb
+++ b/app/views/learning_paths/show.html.erb
@@ -66,8 +66,9 @@
             <div class="learning-path-topic-order"><%= lpt.order %></div>
             <div class="learning-path-topic-title">
               <h4><%= lpt.topic.title %> <i class="icon icon-md expand-icon"></i></h4>
-              <% if lpt.topic.difficulty_level.present? %>
-                <span class="label label-default"><%= display_difficulty_level(lpt.topic.difficulty_level) %></span>
+              <% competency = display_difficulty_level(lpt.topic.difficulty_level) %>
+              <% if competency %>
+                <span class="label label-default"><%= competency %></span>
               <% end %>
               <span class="label label-default">
                 <i class="fa fa-book"></i> <%= pluralize(lpt.topic.material_items.count, 'material') %>

--- a/app/views/learning_paths/show.html.erb
+++ b/app/views/learning_paths/show.html.erb
@@ -67,7 +67,7 @@
             <div class="learning-path-topic-title">
               <h4><%= lpt.topic.title %> <i class="icon icon-md expand-icon"></i></h4>
               <% if lpt.topic.difficulty_level.present? %>
-                <span class="label label-default"><%= display_difficulty_level(lpt.topic) %></span>
+                <span class="label label-default"><%= display_difficulty_level(lpt.topic.difficulty_level) %></span>
               <% end %>
               <span class="label label-default">
                 <i class="fa fa-book"></i> <%= pluralize(lpt.topic.material_items.count, 'material') %>

--- a/app/views/materials/_form.html.erb
+++ b/app/views/materials/_form.html.erb
@@ -93,7 +93,7 @@
 
   <!-- Field: Level -->
   <%= f.input :difficulty_level, collection: DifficultyDictionary.instance.options_for_select,
-              label: 'Competency level', prompt: 'Select a difficulty level...', field_lock: true,
+              prompt: 'Select a difficulty level...', field_lock: true,
               errors: @material.errors[:difficulty_level], input_html: { title: t('materials.hints.difficulty') },
               visibility_toggle: TeSS::Config.feature['materials_disabled'] %>
 

--- a/app/views/materials/_material.html.erb
+++ b/app/views/materials/_material.html.erb
@@ -34,7 +34,7 @@
         <% end %>
       </div>
 
-      <div class="font-size-lg"><%= display_difficulty_level(material) %></div>
+      <div class="font-size-lg"><%= display_difficulty_level(material.difficulty_level) %></div>
 
       <%= keywords_and_topics(material, limit: 10) %>
     </div>

--- a/app/views/materials/_material.html.erb
+++ b/app/views/materials/_material.html.erb
@@ -34,7 +34,10 @@
         <% end %>
       </div>
 
-      <div class="font-size-lg"><%= display_difficulty_level(material.difficulty_level) %></div>
+      <% competency = display_difficulty_level(material.difficulty_level) %>
+      <% if competency %>
+        <div class="font-size-lg"><%= competency %></div>
+      <% end %>
 
       <%= keywords_and_topics(material, limit: 10) %>
     </div>

--- a/app/views/workflows/_workflow.html.erb
+++ b/app/views/workflows/_workflow.html.erb
@@ -11,6 +11,10 @@
       </h4>
     </div>
 
+    <% if workflow.difficulty_level.present? %>
+      <div class="font-size-lg"><%= display_difficulty_level(workflow.difficulty_level) %></div>
+    <% end %>
+
     <div class="markdown-description">
       <%= render_sanitized_markdown truncate(workflow.description, length: 300, separator: ' ') %>
     </div>

--- a/app/views/workflows/_workflow.html.erb
+++ b/app/views/workflows/_workflow.html.erb
@@ -11,8 +11,9 @@
       </h4>
     </div>
 
-    <% if workflow.difficulty_level.present? %>
-      <div class="font-size-lg"><%= display_difficulty_level(workflow.difficulty_level) %></div>
+    <% competency = display_difficulty_level(workflow.difficulty_level) %>
+    <% if competency %>
+      <div class="font-size-lg"><%= competency %></div>
     <% end %>
 
     <div class="markdown-description">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -75,6 +75,8 @@ en:
         name: 'Name'
       material:
         difficulty_level: Competency level
+      learning_path:
+        difficulty_level: Competency level
       learning_path_topic:
         difficulty_level: Competency level
       workflow:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,6 +73,12 @@ en:
         default_language: 'Default language'
       person:
         name: 'Name'
+      material:
+        difficulty_level: Competency level
+      learning_path_topic:
+        difficulty_level: Competency level
+      workflow:
+        difficulty_level: Competency level
   about:
     headings:
       events: Events
@@ -840,8 +846,9 @@ en:
       user: Owner
       organizer: Organiser
     titles:
-      language: 'Language'
-      date_added: 'Date added'
+      language: Language
+      date_added: Date added
+      difficulty_level: Competency level
   languages: # Only needed to override default names from I18nData
     el: 'Greek'
   errors:


### PR DESCRIPTION
**Summary of changes**

- Displays competency level in: learning path topics index, learning path topic show page, material show page, workflow show page.
- Use label "Competency level" consistently across the site (in form, metadata and filter title)

**Motivation and context**

#1248

**Screenshots**

<img width="526" height="152" alt="image" src="https://github.com/user-attachments/assets/63b174e9-915e-4be9-9f8d-916094226939" />

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree to license it to the TeSS codebase under the [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
