### PR TITLE
Learning path display options

### DIFF
--- a/app/assets/javascripts/learning_paths.js
+++ b/app/assets/javascripts/learning_paths.js
@@ -1,6 +1,6 @@
 var LearningPaths = {
     init: function () {
-        $('.learning-path-topic-title').click(function () {
+        $('.learning-path-topic:not(.single-topic) .learning-path-topic-title').click(function () {
             const container = $(this).closest('.learning-path-topic');
             const contents = container.find('.learning-path-topic-contents');
             $(this).find('.expand-icon, .collapse-icon').toggleClass('collapse-icon').toggleClass('expand-icon');

--- a/app/assets/stylesheets/learning-paths.scss
+++ b/app/assets/stylesheets/learning-paths.scss
@@ -25,7 +25,6 @@
     cursor: pointer;
   }
 
-
   .learning-path-topic-desc {
     border-width: 0;
     padding: 1em;
@@ -35,6 +34,24 @@
 
   .learning-path-topic-contents {
     display: none;
+  }
+
+  &.single-topic {
+    margin-left: 0;
+    border-left: none;
+    padding: 1em;
+
+    .learning-path-topic-title {
+      cursor: unset;
+    }
+
+    .expand-icon, .learning-path-topic-order {
+      display: none;
+    }
+
+    .learning-path-topic-contents {
+      display: block;
+    }
   }
 }
 

--- a/app/assets/stylesheets/learning-paths.scss
+++ b/app/assets/stylesheets/learning-paths.scss
@@ -36,6 +36,12 @@
     display: none;
   }
 
+  &.unordered {
+    .learning-path-topic-order {
+      display: none;
+    }
+  }
+
   &.single-topic {
     margin-left: 0;
     border-left: none;

--- a/app/controllers/learning_paths_controller.rb
+++ b/app/controllers/learning_paths_controller.rb
@@ -109,7 +109,8 @@ class LearningPathsController < ApplicationController
                                           { node_ids: [] }, { node_names: [] },
                                           { topic_links_attributes: [:id, :topic_id, :order, :_destroy] }, :public,
                                           { authors: [:name, :orcid] }, { contributors: [:name, :orcid] }, # Structured
-                                          { authors: [] }, { contributors: [] } # as strings
+                                          { authors: [] }, { contributors: [] }, # as strings
+                                          :unordered
                                           )
   end
 

--- a/app/views/learning_paths/_form.html.erb
+++ b/app/views/learning_paths/_form.html.erb
@@ -130,6 +130,8 @@
 
   <hr>
 
+  <%= f.input :unordered, hint: t('learning_paths.hints.unordered') %>
+
   <%= f.input :public, hint: t('learning_paths.hints.public') %>
 
   <!-- Form Buttons -->

--- a/app/views/learning_paths/show.html.erb
+++ b/app/views/learning_paths/show.html.erb
@@ -64,7 +64,10 @@
         <% topics = @learning_path.topic_links.joins(:topic) %>
         <% topic_count = topics.count %>
         <% topics.each do |lpt| %>
-          <div class="learning-path-topic<%= topic_count == 1 ? ' single-topic' : ''-%>" id="topic-<%= lpt.id -%>">
+          <% classes = ['learning-path-topic'] %>
+          <% classes << 'single-topic' if topic_count == 1 %>
+          <% classes << 'unordered' if @learning_path.unordered? %>
+          <%= content_tag(:div, id: "topic-#{lpt.id}", class: classes) do %>
             <div class="learning-path-topic-order"><%= lpt.order %></div>
             <div class="learning-path-topic-title">
               <h4><%= lpt.topic.title %> <i class="icon icon-md expand-icon"></i></h4>
@@ -91,7 +94,7 @@
                 <% end %>
               </ul>
             </div>
-          </div>
+          <% end %>
         <% end %>
       </div>
     </div>

--- a/app/views/learning_paths/show.html.erb
+++ b/app/views/learning_paths/show.html.erb
@@ -61,8 +61,10 @@
       </div>
 
       <div class="learning-path-topics">
-        <% @learning_path.topic_links.joins(:topic).each do |lpt| %>
-          <div class="learning-path-topic" id="topic-<%= lpt.id -%>">
+        <% topics = @learning_path.topic_links.joins(:topic) %>
+        <% topic_count = topics.count %>
+        <% topics.each do |lpt| %>
+          <div class="learning-path-topic<%= topic_count == 1 ? ' single-topic' : ''-%>" id="topic-<%= lpt.id -%>">
             <div class="learning-path-topic-order"><%= lpt.order %></div>
             <div class="learning-path-topic-title">
               <h4><%= lpt.topic.title %> <i class="icon icon-md expand-icon"></i></h4>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -735,6 +735,7 @@ en:
       url: 'Preferred URL to direct people to your learning path landing page.'
       version: 'Indicate the current version of the learning path.'
       public: Un-ticking this box will hide this learning path from anyone who isn't the creator or a collaborator.
+      unordered: Ticking this box will hide the order numbering of topics when viewing the learning path.
     next_topic: Next topic
     next_item: Next
     end_of: End of learning path

--- a/db/migrate/20260421144919_add_unordered_to_learning_paths.rb
+++ b/db/migrate/20260421144919_add_unordered_to_learning_paths.rb
@@ -1,5 +1,5 @@
 class AddUnorderedToLearningPaths < ActiveRecord::Migration[7.2]
   def change
-    add_column :learning_paths, :unordered, :boolean
+    add_column :learning_paths, :unordered, :boolean, default: false, null: false
   end
 end

--- a/db/migrate/20260421144919_add_unordered_to_learning_paths.rb
+++ b/db/migrate/20260421144919_add_unordered_to_learning_paths.rb
@@ -1,0 +1,5 @@
+class AddUnorderedToLearningPaths < ActiveRecord::Migration[7.2]
+  def change
+    add_column :learning_paths, :unordered, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_17_000001) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_21_144919) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -323,6 +323,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_17_000001) do
     t.datetime "updated_at", null: false
     t.boolean "public", default: true
     t.bigint "space_id"
+    t.boolean "unordered"
     t.index ["content_provider_id"], name: "index_learning_paths_on_content_provider_id"
     t.index ["slug"], name: "index_learning_paths_on_slug", unique: true
     t.index ["space_id"], name: "index_learning_paths_on_space_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -323,7 +323,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_21_144919) do
     t.datetime "updated_at", null: false
     t.boolean "public", default: true
     t.bigint "space_id"
-    t.boolean "unordered"
+    t.boolean "unordered", default: false, null: false
     t.index ["content_provider_id"], name: "index_learning_paths_on_content_provider_id"
     t.index ["slug"], name: "index_learning_paths_on_slug", unique: true
     t.index ["space_id"], name: "index_learning_paths_on_space_id"

--- a/test/controllers/learning_paths_controller_test.rb
+++ b/test/controllers/learning_paths_controller_test.rb
@@ -151,6 +151,8 @@ class LearningPathsControllerTest < ActionController::TestCase
     get :show, params: { id: @learning_path }
     assert_response :success
     assert assigns(:learning_path)
+    assert_select '.learning-path-topic', count: 2
+    assert_select '.learning-path-topic.single-topic', count: 0
   end
 
   test 'should show learning_path as json' do
@@ -560,5 +562,13 @@ class LearningPathsControllerTest < ActionController::TestCase
     assert_redirected_to learning_path_path(lp)
     assert_equal 'Joe', lp.authors.first[:name]
     assert_nil lp.authors.first[:orcid]
+  end
+
+  test 'displays single-topic view if only one topic in the learning path' do
+    get :show, params: { id: learning_paths(:two) }
+    assert_response :success
+    assert assigns(:learning_path)
+    assert_select '.learning-path-topic', count: 1
+    assert_select '.learning-path-topic.single-topic', count: 1
   end
 end

--- a/test/controllers/learning_paths_controller_test.rb
+++ b/test/controllers/learning_paths_controller_test.rb
@@ -152,7 +152,10 @@ class LearningPathsControllerTest < ActionController::TestCase
     assert_response :success
     assert assigns(:learning_path)
     assert_select '.learning-path-topic', count: 2
+    assert_operator assigns(:learning_path).topics.length, :>, 1
     assert_select '.learning-path-topic.single-topic', count: 0
+    refute assigns(:learning_path).unordered?
+    assert_select '.learning-path-topic.unordered', count: 0
   end
 
   test 'should show learning_path as json' do
@@ -570,5 +573,15 @@ class LearningPathsControllerTest < ActionController::TestCase
     assert assigns(:learning_path)
     assert_select '.learning-path-topic', count: 1
     assert_select '.learning-path-topic.single-topic', count: 1
+  end
+
+  test 'displays unordered view when learning path is unordered' do
+    learning_path = learning_paths(:one)
+    learning_path.update!(unordered: true)
+    get :show, params: { id: learning_path }
+    assert_response :success
+    assert assigns(:learning_path)
+    assert assigns(:learning_path).unordered?
+    assert_select '.learning-path-topic.unordered', minimum: 1
   end
 end


### PR DESCRIPTION
**Summary of changes**

- Learning paths with only 1 topic will have that topic expanded by default.
- Adds the option to display learning paths "unordered", which hides the ordering labels from the topic view. 

**Motivation and context**

#1169
#1247

**Screenshots**

LP with only 1 topic:

<img width="1078" height="354" alt="image" src="https://github.com/user-attachments/assets/ca07b373-afb5-4880-8fe4-5e67e504b7c8" />

Unordered LP:

Form:

<img width="813" height="155" alt="image" src="https://github.com/user-attachments/assets/edeb245d-d147-470c-9d4a-218d33ef633c" />

Display:

<img width="808" height="455" alt="image" src="https://github.com/user-attachments/assets/36c92d87-8098-4e32-81d6-2bfbf3d051ec" />

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree to license it to the TeSS codebase under the [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
