### PR TITLE
Event instructors and contributors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ElixirTeSS/TeSS_RDF_Extractors
-  revision: 135ce24ef909bf5f7c6e14ccb1e404b51478ab07
+  revision: 88f54016b4ecea8ac3639315bbe029c9cf891586
   branch: master
   specs:
     tess_rdf_extractors (1.2.0)
@@ -388,7 +388,7 @@ GEM
       net-protocol
     netrc (0.11.0)
     nio4r (2.7.4)
-    nokogiri (1.19.1)
+    nokogiri (1.19.2)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     numerizer (0.1.1)

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -241,7 +241,7 @@ class EventsController < ApplicationController
                                   external_resources_attributes: %i[id url title _destroy],
                                   external_resources: %i[url title], material_ids: [],
                                   llm_interaction_attributes: %i[id scrape_or_process model prompt input output needs_processing _destroy],
-                                  locked_fields: [])
+                                  locked_fields: [], instructors: [:name, :orcid], contributors: [:name, :orcid])
   end
 
   def event_report_params

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -20,6 +20,7 @@ class Event < ApplicationRecord
   include HasEdamTerms
   include HasLanguage
   include InSpace
+  include HasPeople
 
   before_validation :fix_keywords, on: :create, if: :scraper_record
   before_validation :presence_default
@@ -51,6 +52,13 @@ class Event < ApplicationRecord
       text :operations do
         operations_and_synonyms
       end
+      text :contributors do
+        contributors.map(&:display_name)
+      end
+      text :instructors do
+        instructors.map(&:display_name)
+      end
+
       # sort title
       string :sort_title do
         title.downcase.gsub(/^(an?|the) /, '')
@@ -105,6 +113,12 @@ class Event < ApplicationRecord
       string :collections, multiple: true do
         collections.where(public: true).pluck(:title)
       end
+      string :contributors, multiple: true do
+        contributors.map(&:display_name)
+      end
+      string :instructors, multiple: true do
+        instructors.map(&:display_name)
+      end
     end
     # :nocov:
   end
@@ -121,11 +135,13 @@ class Event < ApplicationRecord
   has_many :event_materials, dependent: :destroy
   has_many :materials, through: :event_materials
   has_many :widget_logs, as: :resource
+  has_many :stars, as: :resource, dependent: :destroy
 
   has_ontology_terms(:scientific_topics, branch: EDAM.topics)
   has_ontology_terms(:operations, branch: EDAM.operations)
 
-  has_many :stars, as: :resource, dependent: :destroy
+  has_person_role :contributors
+  has_person_role :instructors
 
   auto_strip_attributes :title, :description, :url, squish: false
 
@@ -196,7 +212,7 @@ class Event < ApplicationRecord
   def self.facet_fields
     field_list = %w[ content_provider keywords scientific_topics operations tools fields online event_types
                      start venue city country organizer sponsors target_audience eligibility language
-                     user node collections ]
+                     user node collections contributors instructors]
 
     field_list.delete('operations') if TeSS::Config.feature['disabled'].include? 'operations'
     field_list.delete('scientific_topics') if TeSS::Config.feature['disabled'].include? 'topics'

--- a/app/views/bioschemas/_preview_button.html.erb
+++ b/app/views/bioschemas/_preview_button.html.erb
@@ -1,4 +1,4 @@
-<%= form_tag(polymorphic_path([:preview, resource.class])) do |f| %>
+<%= form_tag(polymorphic_path([:preview, resource.class]), class: 'mt-3') do |f| %>
   <%= attributes_to_hidden_fields(resource.class.model_name.param_key, resource_params) %>
 
   <%= submit_tag('Preview', class: 'btn btn-primary', formtarget: '_blank', data: { disable_with: false }) %>

--- a/app/views/common/_extra_metadata.html.erb
+++ b/app/views/common/_extra_metadata.html.erb
@@ -61,6 +61,7 @@
 
 <%= display_people(resource, :authors) if resource.respond_to?(:authors) %>
 <%= display_people(resource, :contributors) if resource.respond_to?(:contributors) %>
+<%= display_people(resource, :instructors) if resource.respond_to?(:instructors) %>
 <%= display_attribute(resource, :remote_created_date) if resource.respond_to?(:remote_created_date) %>
 <%= display_attribute(resource, :remote_updated_date) if resource.respond_to?(:remote_updated_date) %>
 <%= display_attribute(resource, :scientific_topics) { 

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -175,6 +175,12 @@
     <%= f.multi_input :sponsors, errors: @event.errors[:sponsors], hint: t('events.hints.sponsors') %>
   <% end %>
 
+  <!-- Field: Contributors -->
+  <%= render partial: "common/people_form", locals: { f: f, field_name: 'contributors', role: 'contributor' } %>
+
+  <!-- Field: Instructors -->
+  <%= render partial: "common/people_form", locals: { f: f, field_name: 'instructors', role: 'instructor' } %>
+
   <div class="form-group">
     <%= f.submit(class: 'btn btn-primary') %>
     <%= link_to 'Back', :back, class: 'btn btn-default' %>

--- a/lib/bioschemas/course_instance_generator.rb
+++ b/lib/bioschemas/course_instance_generator.rb
@@ -20,5 +20,7 @@ module Bioschemas
     }
     property :maximumAttendeeCapacity, :capacity
     property :courseMode, :presence
+    property :contributor, -> (event) { event.contributors.map { |p| person(p) } }
+    property :instructor, -> (event) { event.instructors.map { |p| person(p) } }
   end
 end

--- a/test/integration/bioschemas_test.rb
+++ b/test/integration/bioschemas_test.rb
@@ -80,6 +80,8 @@ class BioschemasTest < ActionDispatch::IntegrationTest
     event = events(:course_event)
     event.external_resources.create!({ title: 'Cool website', url: 'https://external-resource.pizza' })
     event.node_names = ['Test Node']
+    event.contributors = [{ name: 'Contri Butor', orcid: '0000-0002-1694-233X' }]
+    event.instructors = [{ name: 'Josiah Carberry', orcid: 'https://orcid.org/0000-0002-1825-0097' }, { name: 'Gordon Freeman' }]
     event.save!
     url = event_url(event.slug)
 
@@ -213,6 +215,37 @@ class BioschemasTest < ActionDispatch::IntegrationTest
     assert_includes providers, ['ELIXIR Test Node', 'http://example.com']
     assert_includes providers, ['Goblet', 'http://mygoblet.org']
     assert_includes providers, ['University of Manchester', nil]
+
+    # Contributors
+    q = RDF::Query.new do
+      pattern RDF::Query::Pattern.new(course_instance_uri, RDF::Vocab::SCHEMA.contributor, :contributor_info)
+      pattern RDF::Query::Pattern.new(:contributor_info, RDF::Vocab::SCHEMA.name, :name)
+      pattern RDF::Query::Pattern.new(:contributor_info, RDF::Vocab::SCHEMA.identifier, :identifier, optional: true)
+    end
+    results = graph.query(q)
+    assert_equal 1, results.count
+    contributors = results.map { |r| { name: r.name.to_s,
+                                       id: r.contributor_info.to_s.start_with?('http') ? r.contributor_info.to_s : nil,
+                                       identifier: r[:identifier]&.to_s }}
+    assert_includes contributors, { name: 'Contri Butor',
+                                    id: 'https://orcid.org/0000-0002-1694-233X',
+                                    identifier: 'https://orcid.org/0000-0002-1694-233X' }
+
+    # Instructors
+    q = RDF::Query.new do
+      pattern RDF::Query::Pattern.new(course_instance_uri, RDF::Vocab::SCHEMA.instructor, :instructor_info)
+      pattern RDF::Query::Pattern.new(:instructor_info, RDF::Vocab::SCHEMA.name, :name)
+      pattern RDF::Query::Pattern.new(:instructor_info, RDF::Vocab::SCHEMA.identifier, :identifier, optional: true)
+    end
+    results = graph.query(q)
+    assert_equal 2, results.count
+    instructors = results.map { |r| { name: r.name.to_s,
+                                      id: r.instructor_info.to_s.start_with?('http') ? r.instructor_info.to_s : nil,
+                                      identifier: r[:identifier]&.to_s }}
+    assert_includes instructors, { name: 'Josiah Carberry',
+                                   id: 'https://orcid.org/0000-0002-1825-0097',
+                                   identifier: 'https://orcid.org/0000-0002-1825-0097' }
+    assert_includes instructors, { name: 'Gordon Freeman', id: nil, identifier: nil }
   end
 
   test 'handles non-list markdown for prereqs on course event' do

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -804,4 +804,64 @@ class EventTest < ActiveSupport::TestCase
 
     assert_equal 1, (e.reload.ontology_term_links.to_a - ontology_term_links).length
   end
+
+  test 'should set contributors from array of hashes' do
+    @event.contributors = [
+      { name: 'John Doe', orcid: '0000-0002-1825-0097' },
+      { name: 'Jane Smith' }
+    ]
+    @event.save!
+    @event.reload
+
+    assert_equal 2, @event.contributors.size
+    john = @event.contributors.find { |c| c.name == 'John Doe' }
+    assert_not_nil john
+    assert_equal '0000-0002-1825-0097', john.orcid
+  end
+
+  test 'should set contributors from array of Person objects' do
+    person1 = Person.new(resource: @event, name: 'Alice Wonder')
+    person2 = Person.new(resource: @event, name: 'Bob Builder')
+
+
+    assert_not_includes @event.contributors.map(&:name), person1.name
+
+    @event.contributors = [person1, person2]
+    @event.save!
+    @event.reload
+
+    assert_equal 2, @event.contributors.size
+    assert_includes @event.contributors.map(&:name), person1.name
+    assert_includes @event.contributors.map(&:name), person2.name
+  end
+
+  test 'should set instructors from array of hashes' do
+    @event.instructors = [
+      { name: 'John Doe', orcid: '0000-0002-1825-0097' },
+      { name: 'Jane Smith' }
+    ]
+    @event.save!
+    @event.reload
+
+    assert_equal 2, @event.instructors.size
+    john = @event.instructors.find { |c| c.name == 'John Doe' }
+    assert_not_nil john
+    assert_equal '0000-0002-1825-0097', john.orcid
+  end
+
+  test 'should set instructors from array of Person objects' do
+    person1 = Person.new(resource: @event, name: 'Alice Wonder')
+    person2 = Person.new(resource: @event, name: 'Bob Builder')
+
+
+    assert_not_includes @event.instructors.map(&:name), person1.name
+
+    @event.instructors = [person1, person2]
+    @event.save!
+    @event.reload
+
+    assert_equal 2, @event.instructors.size
+    assert_includes @event.instructors.map(&:name), person1.name
+    assert_includes @event.instructors.map(&:name), person2.name
+  end
 end


### PR DESCRIPTION
**Summary of changes**

- Allow contributors and instructors to be credited for events.
- Allows filtering/searching by these fields.
- Extracts from and serializes into the `instructor` and `contributor` fields of `CourseInstance`.

**Motivation and context**

#993

**Screenshots**

(Paste or upload any relevant screenshots)

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree to license it to the TeSS codebase under the [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
