### PR TITLE
GlobalSpace & DefaultSpace

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -114,7 +114,7 @@ class ApplicationController < ActionController::Base
   end
 
   def set_current_space
-    Space.current_space = TeSS::Config.feature['spaces'] ? Space.find_by_host(request.host) : nil
+    Space.current_space = TeSS::Config.feature['spaces'] ? Space.find_by_host(request.host) : Space.default
   end
 
   def current_space

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -114,7 +114,7 @@ class ApplicationController < ActionController::Base
   end
 
   def set_current_space
-    Space.current_space = TeSS::Config.feature['spaces'] ? Space.find_by_host(request.host) : Space.default
+    Space.current_space = TeSS::Config.feature['spaces'] ? Space.find_by_host(request.host) : nil
   end
 
   def current_space

--- a/app/models/default_space.rb
+++ b/app/models/default_space.rb
@@ -1,67 +1,25 @@
-class DefaultSpace
-  class Image
-    def url
-      TeSS::Config.site['logo']
-    end
-  end
-
-  def id
-    nil
-  end
-
-  def title
-    TeSS::Config.site['title_short']
-  end
-
-  def logo_alt
-    TeSS::Config.site['logo_alt']
-  end
-
-  def theme
-    nil
-  end
-
-  def image?
-    true
-  end
-
-  def image
-    Image.new
-  end
-
+class DefaultSpace < GlobalSpace
   def materials
-    Material.all
+    Material.where(space_id: nil)
   end
 
   def events
-    Event.all
+    Event.where(space_id: nil)
   end
 
   def workflows
-    Workflow.all
+    Workflow.where(space_id: nil)
   end
 
   def collections
-    Collection.all
+    Collection.where(space_id: nil)
   end
 
   def learning_paths
-    LearningPath.all
+    LearningPath.where(space_id: nil)
   end
 
   def learning_path_topics
-    LearningPathTopic.all
-  end
-
-  def default?
-    true
-  end
-
-  def administrators
-    User.with_role('admin')
-  end
-
-  def feature_enabled?(feature)
-    TeSS::Config.feature[feature]
+    LearningPathTopic.where(space_id: nil)
   end
 end

--- a/app/models/global_space.rb
+++ b/app/models/global_space.rb
@@ -1,0 +1,67 @@
+class GlobalSpace
+  class Image
+    def url
+      TeSS::Config.site['logo']
+    end
+  end
+
+  def id
+    nil
+  end
+
+  def title
+    TeSS::Config.site['title_short']
+  end
+
+  def logo_alt
+    TeSS::Config.site['logo_alt']
+  end
+
+  def theme
+    nil
+  end
+
+  def image?
+    true
+  end
+
+  def image
+    Image.new
+  end
+
+  def materials
+    Material.all
+  end
+
+  def events
+    Event.all
+  end
+
+  def workflows
+    Workflow.all
+  end
+
+  def collections
+    Collection.all
+  end
+
+  def learning_paths
+    LearningPath.all
+  end
+
+  def learning_path_topics
+    LearningPathTopic.all
+  end
+
+  def default?
+    true
+  end
+
+  def administrators
+    User.with_role('admin')
+  end
+
+  def feature_enabled?(feature)
+    TeSS::Config.feature[feature]
+  end
+end

--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -44,7 +44,7 @@ class Space < ApplicationRecord
   end
 
   def self.default
-    DefaultSpace.new
+    TeSS::Config.feature['spaces'] ? DefaultSpace.new : GlobalSpace.new
   end
 
   def logo_alt

--- a/test/integration/sitemap_test.rb
+++ b/test/integration/sitemap_test.rb
@@ -43,10 +43,10 @@ class SitemapTest < ActionDispatch::IntegrationTest
       SitemapGenerator::Interpreter.run(verbose: false)
     end
 
-    # Global sitemap should include all content
-    global_urls = parse
-    assert_includes global_urls, material_url(materials(:good_material))
-    assert_includes global_urls, material_url(materials(:plant_space_material))
+    # Default sitemap should only include default space content (content with null `space_id`)
+    default_space_urls = parse
+    assert_includes default_space_urls, material_url(materials(:good_material))
+    refute_includes default_space_urls, material_url(materials(:plant_space_material))
 
     # Space sitemap should only include content for that space
     space_urls = parse_space(space)
@@ -54,6 +54,17 @@ class SitemapTest < ActionDispatch::IntegrationTest
     assert_includes space_urls, "#{space.url}/about"
     assert_includes space_urls, "#{space.url}/materials/#{materials(:plant_space_material).friendly_id}"
     refute_includes space_urls, "#{space.url}/materials/#{materials(:good_material).friendly_id}"
+  end
+
+  test 'generates global sitemap when spaces feature is not enabled' do
+    with_settings(feature: { spaces: false }) do
+      SitemapGenerator::Interpreter.run(verbose: false)
+    end
+
+    # Global sitemap should include all content
+    global_urls = parse
+    assert_includes global_urls, material_url(materials(:good_material))
+    assert_includes global_urls, material_url(materials(:plant_space_material))
   end
 
   private

--- a/test/models/space_test.rb
+++ b/test/models/space_test.rb
@@ -216,4 +216,32 @@ class SpaceTest < ActiveSupport::TestCase
       assert_equal 'https://plants.mytess.training', @space.url
     end
   end
+
+  test 'get default space' do
+    with_settings(feature: { spaces: false }) do
+      assert Space.default.is_a?(GlobalSpace)
+    end
+
+    with_settings(feature: { spaces: true }) do
+      assert Space.default.is_a?(DefaultSpace)
+    end
+  end
+
+  test 'resources scoped to space' do
+    plant_materials = spaces(:plants).materials.all.to_a
+    assert_includes plant_materials, materials(:plant_space_material)
+    assert_not_includes plant_materials, materials(:good_material)
+
+    astro_materials = spaces(:astro).materials.all.to_a
+    assert_not_includes astro_materials, materials(:plant_space_material)
+    assert_not_includes astro_materials, materials(:good_material)
+
+    default_materials = DefaultSpace.new.materials.all.to_a
+    assert_not_includes default_materials, materials(:plant_space_material)
+    assert_includes default_materials, materials(:good_material)
+
+    all_materials = GlobalSpace.new.materials.all.to_a
+    assert_includes all_materials, materials(:plant_space_material)
+    assert_includes all_materials, materials(:good_material)
+  end
 end


### PR DESCRIPTION
**Summary of changes**

- Separate `GlobalSpace` and `DefaultSpace` concepts. The former includes all resources, the latter includes only "default space" resources (where `space_id` is null).

**Motivation and context**

#1286

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree to license it to the TeSS codebase under the [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
