### PR TITLE
make keywords available for controlled vocabulary

### DIFF
--- a/app/dictionaries/dictionary.rb
+++ b/app/dictionaries/dictionary.rb
@@ -78,7 +78,11 @@ class Dictionary
   private
 
   def load_dictionary
-    YAML.safe_load(File.read(dictionary_filepath)).with_indifferent_access
+    if File.exist?(dictionary_filepath)
+      YAML.safe_load(File.read(dictionary_filepath)).with_indifferent_access
+    else
+      {}
+    end
   end
 
   def get_file_path(config_file, default_file)

--- a/app/dictionaries/dictionary.rb
+++ b/app/dictionaries/dictionary.rb
@@ -75,14 +75,14 @@ class Dictionary
     @dictionary.keys
   end
 
+  def configured?
+    File.exist?(dictionary_filepath)
+  end
+
   private
 
   def load_dictionary
-    if File.exist?(dictionary_filepath)
-      YAML.safe_load(File.read(dictionary_filepath)).with_indifferent_access
-    else
-      {}
-    end
+    YAML.safe_load(File.read(dictionary_filepath)).with_indifferent_access
   end
 
   def get_file_path(config_file, default_file)

--- a/app/dictionaries/keywords_dictionary.rb
+++ b/app/dictionaries/keywords_dictionary.rb
@@ -1,0 +1,12 @@
+# Dictionary of Keywords
+class KeywordsDictionary < Dictionary
+
+  DEFAULT_FILE = 'keywords.yml'
+
+  private
+
+  def dictionary_filepath
+    get_file_path 'keywords', DEFAULT_FILE
+  end
+
+end

--- a/app/dictionaries/keywords_dictionary.rb
+++ b/app/dictionaries/keywords_dictionary.rb
@@ -3,8 +3,6 @@ class KeywordsDictionary < Dictionary
 
   DEFAULT_FILE = 'keywords.yml'
 
-  private
-
   def dictionary_filepath
     get_file_path 'keywords', DEFAULT_FILE
   end

--- a/app/dictionaries/keywords_dictionary.rb
+++ b/app/dictionaries/keywords_dictionary.rb
@@ -3,8 +3,14 @@ class KeywordsDictionary < Dictionary
 
   DEFAULT_FILE = 'keywords.yml'
 
+  private
+
   def dictionary_filepath
     get_file_path 'keywords', DEFAULT_FILE
+  end
+
+  def load_dictionary
+    configured? ? super : {}
   end
 
 end

--- a/app/dictionaries/target_audience_dictionary.rb
+++ b/app/dictionaries/target_audience_dictionary.rb
@@ -3,8 +3,6 @@ class TargetAudienceDictionary < Dictionary
 
   DEFAULT_FILE = 'target_audience.yml'
 
-  private
-
   def dictionary_filepath
     get_file_path 'target_audience', DEFAULT_FILE
   end

--- a/app/dictionaries/target_audience_dictionary.rb
+++ b/app/dictionaries/target_audience_dictionary.rb
@@ -3,8 +3,14 @@ class TargetAudienceDictionary < Dictionary
 
   DEFAULT_FILE = 'target_audience.yml'
 
+  private
+
   def dictionary_filepath
     get_file_path 'target_audience', DEFAULT_FILE
+  end
+
+  def load_dictionary
+    configured? ? super : {}
   end
 
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -362,6 +362,7 @@ module ApplicationHelper
     def dropdown(name, options = {})
       existing_values = object.send(name.to_sym)
       existing = options[:options].select { |_label, value| existing_values.include?(value) }
+      visibility_toggle = options[:visibility_toggle] || []
       @template.render(partial: 'common/dropdown', locals: { field_name: name, f: self,
                                                              model_name: options[:model_name],
                                                              resource: object,
@@ -370,7 +371,8 @@ module ApplicationHelper
                                                              field_label: options[:label],
                                                              required: options[:required],
                                                              errors: options[:errors],
-                                                             title: options[:title] })
+                                                             title: options[:title],
+                                                             hidden: hidden?(name, visibility_toggle) })
     end
 
     def hidden?(name, visibility_toggle)

--- a/app/views/common/_dropdown.html.erb
+++ b/app/views/common/_dropdown.html.erb
@@ -25,13 +25,6 @@ render :partial => 'common/dropdown',
   options ||= format_for_dropdown(field_name.capitalize.constantize.all)
   existing ||= format_for_dropdown(resource.send(field_name.pluralize))
 
-  # Remove existing objects from the pool of options
-  options = options - existing
-  dropdown_toggle_button_name ||= ''
-  if dropdown_toggle_button_name.blank?
-    dropdown_toggle_button_name = "Add #{field_name.to_s.sub(/_ids?\z/, '').humanize}"
-  end
-
   # show the required label?
   required ||= false
 
@@ -43,6 +36,14 @@ render :partial => 'common/dropdown',
 
   # check title
   title ||= ''
+
+  # Remove existing objects from the pool of options
+  options = options - existing
+  dropdown_toggle_button_name ||= ''
+  if dropdown_toggle_button_name.blank?
+    dropdown_toggle_button_name = "Add #{field_label.to_s.sub(/_ids?\z/, '').humanize}"
+  end
+
 %>
 
 <div class="form-group<%= ' has-error' if errors.size > 0 %>">

--- a/app/views/common/_dropdown.html.erb
+++ b/app/views/common/_dropdown.html.erb
@@ -46,7 +46,7 @@ render :partial => 'common/dropdown',
 
 %>
 
-<div class="form-group<%= ' has-error' if errors.size > 0 %>">
+<div class="form-group<%= ' has-error' if errors.size > 0 %><%= ' hidden' if hidden %>">
 
   <% if required %><label class="control-label string required"><abbr title="required">*</abbr></label><% end %>
   <%= f.label field_label, class: 'control-label' %>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -90,8 +90,16 @@
                     title: t('events.hints.hosts') %>
 
   <!-- Field: Keywords -->
-  <%= f.multi_input :keywords, errors: @event.errors[:keywords],
-                    title: t('events.hints.keywords') %>
+  <% if TeSS::Config.feature['controlled_vocabulary_vars'].include? 'keywords' %>
+    <%= f.dropdown :keywords,
+                  options: KeywordsDictionary.instance.options_for_select,
+                  label: t('activerecord.attributes.event.keywords'),
+                  errors: @event.errors[:keywords],
+                  title: t('events.hints.keywords') %>
+  <% else %>
+    <%= f.multi_input :keywords, errors: @event.errors[:keywords],
+                      title: t('events.hints.keywords') %>
+  <% end %>
 
   <!-- Field: Fields -->
   <% if !TeSS::Config.feature['disabled'].include? 'ardc_fields_of_research' %>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -90,10 +90,10 @@
                     title: t('events.hints.hosts') %>
 
   <!-- Field: Keywords -->
-  <% if TeSS::Config.feature['controlled_vocabulary_vars'].include? 'keywords' %>
+  <% if TeSS::Config.feature['controlled_vocabulary_vars'].include? 'keywords' && File.exist?(KeywordsDictionary.instance.dictionary_filepath) %>
     <%= f.dropdown :keywords,
                   options: KeywordsDictionary.instance.options_for_select,
-                  label: t('activerecord.attributes.event.keywords'),
+                  label: t('activerecord.attributes.event.keywords', default: 'Keywords'),
                   errors: @event.errors[:keywords],
                   title: t('events.hints.keywords') %>
   <% else %>
@@ -113,7 +113,7 @@
   <% end %>
 
   <!-- Field: Target Audience -->
-  <% if TeSS::Config.feature['controlled_vocabulary_vars'].include? 'target_audience' %>
+  <% if TeSS::Config.feature['controlled_vocabulary_vars'].include? 'target_audience' && File.exist?(TargetAudienceDictionary.instance.dictionary_filepath) %>
     <%= f.dropdown :target_audience,
                   options: TargetAudienceDictionary.instance.options_for_select,
                   label: 'Target audiences',

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -90,7 +90,7 @@
                     title: t('events.hints.hosts') %>
 
   <!-- Field: Keywords -->
-  <% if TeSS::Config.feature['controlled_vocabulary_vars'].include? 'keywords' && File.exist?(KeywordsDictionary.instance.dictionary_filepath) %>
+  <% if TeSS::Config.feature['controlled_vocabulary_vars'].include? 'keywords' && KeywordsDictionary.instance.configured? %>
     <%= f.dropdown :keywords,
                   options: KeywordsDictionary.instance.options_for_select,
                   label: t('activerecord.attributes.event.keywords', default: 'Keywords'),
@@ -113,7 +113,7 @@
   <% end %>
 
   <!-- Field: Target Audience -->
-  <% if TeSS::Config.feature['controlled_vocabulary_vars'].include? 'target_audience' && File.exist?(TargetAudienceDictionary.instance.dictionary_filepath) %>
+  <% if TeSS::Config.feature['controlled_vocabulary_vars'].include? 'target_audience' && TargetAudienceDictionary.instance.configured? %>
     <%= f.dropdown :target_audience,
                   options: TargetAudienceDictionary.instance.options_for_select,
                   label: 'Target audiences',

--- a/app/views/materials/_form.html.erb
+++ b/app/views/materials/_form.html.erb
@@ -37,7 +37,16 @@
   <hr>
 
   <!-- Field: Keywords -->
-  <%= f.multi_input :keywords, title: t('materials.hints.keywords'), visibility_toggle: TeSS::Config.feature['materials_disabled'] %>
+  <% if TeSS::Config.feature['controlled_vocabulary_vars'].include? 'keywords' %>
+    <%= f.dropdown :keywords,
+                  options: KeywordsDictionary.instance.options_for_select,
+                  label: t('activerecord.attributes.event.keywords'),
+                  errors: @material.errors[:keywords],
+                  title: t('events.hints.keywords'),
+                  visibility_toggle: TeSS::Config.feature['materials_disabled'] %>
+  <% else %>
+    <%= f.multi_input :keywords, title: t('materials.hints.keywords'), visibility_toggle: TeSS::Config.feature['materials_disabled'] %>
+  <% end %>
 
   <!-- Field: Licence -->
   <%= f.input :licence, collection: licence_options_for_select, as: :grouped_select, group_method: :last, group_label_method: :first,

--- a/app/views/materials/_form.html.erb
+++ b/app/views/materials/_form.html.erb
@@ -40,9 +40,9 @@
   <% if TeSS::Config.feature['controlled_vocabulary_vars'].include? 'keywords' %>
     <%= f.dropdown :keywords,
                   options: KeywordsDictionary.instance.options_for_select,
-                  label: t('activerecord.attributes.event.keywords'),
+                  label: t('activerecord.attributes.event.keywords', default: 'Keywords'),
                   errors: @material.errors[:keywords],
-                  title: t('events.hints.keywords'),
+                  title: t('materials.hints.keywords'),
                   visibility_toggle: TeSS::Config.feature['materials_disabled'] %>
   <% else %>
     <%= f.multi_input :keywords, title: t('materials.hints.keywords'), visibility_toggle: TeSS::Config.feature['materials_disabled'] %>

--- a/app/views/materials/_form.html.erb
+++ b/app/views/materials/_form.html.erb
@@ -37,7 +37,7 @@
   <hr>
 
   <!-- Field: Keywords -->
-  <% if TeSS::Config.feature['controlled_vocabulary_vars'].include? 'keywords' %>
+  <% if TeSS::Config.feature['controlled_vocabulary_vars'].include? 'keywords' && KeywordsDictionary.instance.configured? %>
     <%= f.dropdown :keywords,
                   options: KeywordsDictionary.instance.options_for_select,
                   label: t('activerecord.attributes.event.keywords', default: 'Keywords'),

--- a/config/dictionaries/keywords.yml
+++ b/config/dictionaries/keywords.yml
@@ -1,0 +1,3 @@
+placeholder:
+  title: placeholder
+  description: 'Placeholder'

--- a/config/dictionaries/keywords.yml
+++ b/config/dictionaries/keywords.yml
@@ -1,3 +1,0 @@
-placeholder:
-  title: placeholder
-  description: 'Placeholder'

--- a/config/tess.example.yml
+++ b/config/tess.example.yml
@@ -168,7 +168,7 @@ default: &default
     bioschemas_testing: false
     collection_curation: true
     auto_parse_vars: [] # available features to auto parse from description: ['keywords', 'target_audience']
-    controlled_vocabulary_vars: [] # available features: ['target_audience']
+    controlled_vocabulary_vars: [] # available features: ['keywords', 'target_audience']
 
     # User login
     invitation: false


### PR DESCRIPTION
**Summary of changes**
Enable controlled vocabulary dropdown for keywords

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree to license it to the TeSS codebase under the [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
