### PR TITLE
Multiple ontology support

### DIFF
--- a/app/models/concerns/has_terms_and_synonyms.rb
+++ b/app/models/concerns/has_terms_and_synonyms.rb
@@ -1,17 +1,17 @@
-module HasEdamTerms
+module HasTermsAndSynonyms
   extend ActiveSupport::Concern
 
   def scientific_topics_and_synonyms
-    edam_term_names_and_synonyms(scientific_topics)
+    term_names_and_synonyms(scientific_topics)
   end
 
   def operations_and_synonyms
-    edam_term_names_and_synonyms(operations)
+    term_names_and_synonyms(operations)
   end
 
   private
 
-  def edam_term_names_and_synonyms(terms)
+  def term_names_and_synonyms(terms)
     terms.map do |term|
       [term.preferred_label] + term.has_exact_synonym + term.has_narrow_synonym
     end.flatten.uniq

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -17,7 +17,7 @@ class Event < ApplicationRecord
   include HasFriendlyId
   include FuzzyDictionaryMatch
   include WithTimezone
-  include HasEdamTerms
+  include HasTermsAndSynonyms
   include HasLanguage
   include InSpace
   include HasPeople

--- a/app/models/material.rb
+++ b/app/models/material.rb
@@ -19,7 +19,7 @@ class Material < ApplicationRecord
   include IdentifiersDotOrg
   include HasFriendlyId
   include HasDifficultyLevel
-  include HasEdamTerms
+  include HasTermsAndSynonyms
   include InSpace
   include HasPeople
 

--- a/app/models/ontology_term_link.rb
+++ b/app/models/ontology_term_link.rb
@@ -6,6 +6,7 @@ class OntologyTermLink < ApplicationRecord
   end
 
   def ontology
-    Edam::Ontology.instance
+    @ontology ||= Ontology.subclasses.map(&:instance).\
+                    find { |ontology| ontology.term_uri_matches?(term_uri) }
   end
 end

--- a/app/models/ontology_term_link.rb
+++ b/app/models/ontology_term_link.rb
@@ -2,7 +2,7 @@ class OntologyTermLink < ApplicationRecord
   belongs_to :resource, polymorphic: true
 
   def ontology_term
-    ontology.lookup(term_uri)
+    ontology&.lookup(term_uri)
   end
 
   def ontology

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -10,7 +10,7 @@ class Workflow < ApplicationRecord
   include HasFriendlyId
   include CurationQueue
   include HasDifficultyLevel
-  include HasEdamTerms
+  include HasTermsAndSynonyms
   include InSpace
   include HasPeople
 

--- a/app/ontologies/edam/ontology.rb
+++ b/app/ontologies/edam/ontology.rb
@@ -31,5 +31,13 @@ module Edam
       result = graph.query(query).first
       lookup(result.u) if result
     end
+
+    def scoped_lookup_by_name_or_synonym(name, subset = :_)
+      out = scoped_lookup_by_name(name, subset)
+      return out unless out.blank?
+      out = find_by(OBO.hasExactSynonym, name)
+      return out unless out.blank?
+      find_by(OBO.hasNarrowSynonym, name)
+    end
   end
 end

--- a/app/ontologies/ontology.rb
+++ b/app/ontologies/ontology.rb
@@ -11,6 +11,11 @@ class Ontology
     raise NotImplementedError
   end
 
+  def scoped_lookup_by_name_or_synonym(name, subset = :_)
+    # Must implement in subclass ...
+    raise NotImplementedError
+  end
+
   def term_uri_matches?(uri)
     uri.starts_with?(self.uri)
   end

--- a/app/ontologies/ontology.rb
+++ b/app/ontologies/ontology.rb
@@ -6,6 +6,15 @@ class Ontology
     @query_cache = {}
   end
 
+  def uri
+    # Must implement in subclass ...
+    raise NotImplementedError
+  end
+
+  def term_uri_matches?(uri)
+    uri.starts_with?(self.uri)
+  end
+
   def lookup(uri)
     @term_cache[RDF::URI(uri)] ||= fetch(uri)
   end

--- a/lib/has_ontology_terms.rb
+++ b/lib/has_ontology_terms.rb
@@ -96,7 +96,7 @@ module HasOntologyTerms
 
       # OntologyTerm objects
       define_method method do
-        send(links_method).map(&:ontology_term).uniq
+        send(links_method)&.compact&.map(&:ontology_term)&.uniq&.compact
       end
 
       define_method "#{method}=" do |terms|
@@ -105,7 +105,7 @@ module HasOntologyTerms
 
       # Names/Labels
       define_method names_method do
-        send(method).map(&:preferred_label).uniq
+        send(method)&.compact&.map(&:preferred_label)&.uniq
       end
 
       define_method "#{names_method}=" do |names|
@@ -130,7 +130,7 @@ module HasOntologyTerms
 
       # URIs
       define_method uris_method do
-        send(method).map(&:uri).uniq
+        send(method)&.compact&.map(&:uri)&.uniq
       end
 
       define_method "#{uris_method}=" do |uris|

--- a/lib/has_ontology_terms.rb
+++ b/lib/has_ontology_terms.rb
@@ -43,8 +43,12 @@ module HasOntologyTerms
                dependent: :destroy,
                inverse_of: :resource
 
-      cattr_accessor :ontology_term_fields
-      self.ontology_term_fields ||= []
+      # Previously used cattr_accessor, which uses "@@" variables that mess with inheritance.
+      # So we do this instead (use "@" class vars)...
+      def self.ontology_term_fields
+        @ontology_term_fields ||= []
+      end
+
       self.ontology_term_fields << method.to_sym
 
       define_method "#{links_method}=" do |links|

--- a/lib/has_ontology_terms.rb
+++ b/lib/has_ontology_terms.rb
@@ -22,7 +22,22 @@ module HasOntologyTerms
   end
 
   module ClassMethods
-    def has_ontology_terms(association_name, ontology: Edam::Ontology.instance, branch: :_) # :_ is essentially a wildcard, meaning it will match any branch.
+    def has_ontology_terms(association_name,
+                           ontology: nil,
+                           branch: nil,
+                           ontologies: nil)
+      unless ontologies
+        ontology ||= Edam::Ontology.instance
+        # :_ is essentially a wildcard, meaning it will match any branch.
+        branch ||= :_
+      else
+        # ontologies is an array of hashes with keys :ontology and :branch
+        ontologies = ontologies.map do |ontology_specification|
+          { ontology: ontology_specification[:ontology] || Edam::Ontology.instance,
+            branch: ontology_specification[:branch] || :_ }
+        end
+      end
+
       method = association_name.to_s
       singular = association_name.to_s.singularize
       links_method = "#{singular}_links"
@@ -89,13 +104,20 @@ module HasOntologyTerms
         terms = []
         [names].flatten.each do |name|
           unless name.blank?
-            st = [ontology.scoped_lookup_by_name(name, branch)].compact # FIXME: This is probably too EDAM specific
-            st = ontology.find_by(OBO.hasExactSynonym, name) if st.empty?
-            st = ontology.find_by(OBO.hasNarrowSynonym, name) if st.empty?
+            st = if ontologies
+                   # TODO: if name is found in first ontology, should it skip others?
+                   ontologies.map do |ontology_specification|
+                     [ontology_specification[:ontology].\
+                        scoped_lookup_by_name_or_synonym(name,
+                                                         ontology_specification[:branch])]
+                   end
+                 else
+                   [ontology.scoped_lookup_by_name_or_synonym(name, branch)]
+                 end
             terms += st
           end
         end
-        send("#{method}=", terms.uniq)
+        send("#{method}=", terms.flatten.compact.uniq)
       end
 
       # URIs
@@ -104,7 +126,15 @@ module HasOntologyTerms
       end
 
       define_method "#{uris_method}=" do |uris|
-        send("#{method}=", uris.map { |uri| ontology.lookup(uri) })
+        terms = if ontologies
+                  ontologies.map do |ontology_specification|
+                    uris.map { |uri| ontology_specification[:ontology].lookup(uri) }
+                  end.flatten
+                else
+                  uris.map { |uri| ontology.lookup(uri) }
+                end
+
+        send("#{method}=", terms)
       end
     end
   end

--- a/lib/has_ontology_terms.rb
+++ b/lib/has_ontology_terms.rb
@@ -59,12 +59,20 @@ module HasOntologyTerms
                inverse_of: :resource
 
       # Previously used cattr_accessor, which uses "@@" variables that mess with inheritance.
-      # So we do this instead (use "@" class vars)...
+      # So we do this instead (use "@" class vars), while explicitly merging inherited
+      # values so STI subclasses still see ontology term fields declared on parent classes.
       def self.ontology_term_fields
-        @ontology_term_fields ||= []
+        inherited_fields = superclass.respond_to?(:ontology_term_fields) ? superclass.ontology_term_fields : []
+        own_fields = @ontology_term_fields ||= []
+        (inherited_fields + own_fields).uniq
       end
 
-      self.ontology_term_fields << method.to_sym
+      def self.add_ontology_term_field(field)
+        @ontology_term_fields ||= []
+        @ontology_term_fields << field unless ontology_term_fields.include?(field)
+      end
+
+      self.add_ontology_term_field(method.to_sym)
 
       define_method "#{links_method}=" do |links|
         send(links_method).reset

--- a/test/unit/has_ontology_terms_test.rb
+++ b/test/unit/has_ontology_terms_test.rb
@@ -1,0 +1,69 @@
+require 'test_helper'
+
+class HasOntologyTermsTest < ActiveSupport::TestCase
+  teardown do
+    DummyMaterial.clear_index!
+  end
+
+  class DummyTerm
+    attr_reader :label, :uri
+    def initialize(term)
+      @label = term
+      @uri = "http://dummy/#{term}"
+    end
+    alias_method :preferred_label, :label
+  end
+
+  class DummyOntology < ::Ontology
+    # A very permissive ontology: it allows any term
+    include Singleton
+
+    def initialize
+    end
+
+    def uri
+      'http://dummy/'
+    end
+
+    def scoped_lookup_by_name(term, subset = :_)
+      return DummyTerm.new(term)
+    end
+
+    def lookup(uri)
+      term = uri[/http:\/\/dummy\/(.*)/,1]
+      return DummyTerm.new(term)
+    end
+  end
+
+  class DummyMaterial < ::Material
+    has_ontology_terms(:test_topics, ontology: DummyOntology.instance)
+
+    # TODO: see similar tests with model subclasses, maybe can be in a module?
+    def self.index
+      (@index ||= Hash.new).values.flatten.uniq
+    end
+
+    def self.add_to_index(m)
+      index
+      @index[m.id] = m.reload.collections.to_a
+    end
+
+    def self.clear_index!
+      @index = Hash.new
+    end
+
+    def solr_index
+      self.class.add_to_index(self)
+    end
+  end
+
+  test 'can create an attribute with ontology terms' do
+    dummy = materials(:good_material).becomes(DummyMaterial)
+    dummy.test_topic_names = ['Bioinformatics']
+    dummy.save!
+
+    assert_equal dummy.test_topics.count, 1
+    assert_equal dummy.test_topic_names, ['Bioinformatics'] 
+    assert_equal dummy.test_topic_uris, ['http://dummy/Bioinformatics'] 
+  end
+end

--- a/test/unit/has_ontology_terms_test.rb
+++ b/test/unit/has_ontology_terms_test.rb
@@ -134,4 +134,55 @@ class HasOntologyTermsTest < ActiveSupport::TestCase
                  Set.new(['http://dummy/Poodles',
                           'http://edamontology.org/topic_3292'])
   end
+
+  test "Ignores attributes that don't come from any ontology" do
+    dummy = materials(:good_material).becomes(DummyMaterial)
+    dummy.ontology_term_links.create(field: :test_topics, term_uri: 'http://not-a-term.com')
+    dummy.ontology_term_links.create(field: :multi_test_topics, term_uri: 'http://also-not-a-term.com')
+
+    assert_equal dummy.ontology_term_links.count, 2
+
+    assert_equal dummy.test_topics, []
+    assert_equal dummy.test_topic_names, []
+    assert_equal dummy.test_topic_uris, []
+
+    assert_equal dummy.multi_test_topics, []
+    assert_equal dummy.multi_test_topic_names, []
+    assert_equal dummy.multi_test_topic_uris, []
+
+    # Setting URI manually wipes out the ontology_term_links
+    dummy.test_topic_uris = ['http://not-a-term.com']
+    dummy.multi_test_topic_uris = ['http://also-not-a-term.com']
+
+    assert_equal dummy.ontology_term_links.count, 0
+
+    # What if there is a term in here already, plus a bogus term link?
+    # (perhaps bogus because a previous ontology was take out).
+    dummy.test_topic_names = ['Bioinformatics']
+    dummy.multi_test_topic_names = ['Biochemistry', 'Bioinformatics', 'Poodles']
+    assert_equal dummy.ontology_term_links.count, 5
+    assert_equal dummy.test_topic_links.count, 1
+    assert_equal dummy.multi_test_topic_links.count, 4
+
+    dummy.ontology_term_links.create(field: :test_topics, term_uri: 'http://not-a-term.com')
+    dummy.ontology_term_links.create(field: :multi_test_topics, term_uri: 'http://also-not-a-term.com')
+    assert_equal dummy.ontology_term_links.count, 7
+    assert_equal dummy.test_topic_links.count, 2
+    assert_equal dummy.multi_test_topic_links.count, 5
+
+    # Terms with bogus URIs don't appear here
+    assert_equal dummy.test_topics.count, 1
+    assert_equal dummy.test_topic_names, ['Bioinformatics']
+    assert_equal dummy.test_topic_uris, ['http://dummy/Bioinformatics']
+
+    assert_equal dummy.multi_test_topics.count, 4
+    # Bioinformatics is in both ontologies
+    assert_equal Set.new(dummy.multi_test_topic_names), Set.new(['Biochemistry', 'Bioinformatics', 'Poodles'])
+    assert_equal Set.new(dummy.multi_test_topic_uris),
+                 Set.new(['http://edamontology.org/topic_3292',
+                          'http://edamontology.org/topic_0091',
+                          'http://dummy/Bioinformatics',
+                          'http://dummy/Poodles'])
+  end
+
 end

--- a/test/unit/has_ontology_terms_test.rb
+++ b/test/unit/has_ontology_terms_test.rb
@@ -1,6 +1,10 @@
 require 'test_helper'
 
 class HasOntologyTermsTest < ActiveSupport::TestCase
+  # Summary: we create attributes 'test_topics' and 'multi_test_topics' for
+  # the fake model DummyMaterial. 'test_topics' uses DummyOntology,
+  # 'multi_test_topics' uses both DummyOntology and Edam::Ontology
+
   teardown do
     DummyMaterial.clear_index!
   end
@@ -15,7 +19,7 @@ class HasOntologyTermsTest < ActiveSupport::TestCase
   end
 
   class DummyOntology < ::Ontology
-    # A very permissive ontology: it allows any term
+    # A very permissive ontology: it allows any term as long as it doesn't have Chemistry in it
     include Singleton
 
     def initialize
@@ -26,17 +30,22 @@ class HasOntologyTermsTest < ActiveSupport::TestCase
     end
 
     def scoped_lookup_by_name(term, subset = :_)
-      return DummyTerm.new(term)
+      return DummyTerm.new(term) unless term =~ /chemistry/i
     end
+    alias_method :scoped_lookup_by_name_or_synonym, :scoped_lookup_by_name
 
     def lookup(uri)
       term = uri[/http:\/\/dummy\/(.*)/,1]
-      return DummyTerm.new(term)
+      return DummyTerm.new(term) unless term.blank?
     end
   end
 
   class DummyMaterial < ::Material
     has_ontology_terms(:test_topics, ontology: DummyOntology.instance)
+    has_ontology_terms(:multi_test_topics,
+                       ontologies: [{ ontology: Edam::Ontology.instance,
+                                      branch: EDAM.topics},
+                                    { ontology: DummyOntology.instance}])
 
     # TODO: see similar tests with model subclasses, maybe can be in a module?
     def self.index
@@ -57,13 +66,72 @@ class HasOntologyTermsTest < ActiveSupport::TestCase
     end
   end
 
-  test 'can create an attribute with ontology terms' do
+  test 'can create an attribute with terms from a single ontology' do
+    # See the Event/Material model tests for many examples of this ...
     dummy = materials(:good_material).becomes(DummyMaterial)
+
+    # This is found in the ontology ...
     dummy.test_topic_names = ['Bioinformatics']
     dummy.save!
-
     assert_equal dummy.test_topics.count, 1
-    assert_equal dummy.test_topic_names, ['Bioinformatics'] 
-    assert_equal dummy.test_topic_uris, ['http://dummy/Bioinformatics'] 
+    assert_equal dummy.test_topic_names, ['Bioinformatics']
+    assert_equal dummy.test_topic_uris, ['http://dummy/Bioinformatics']
+
+    # This is not
+    dummy.test_topic_names = ['Biochemistry']
+    dummy.save!
+    assert_equal dummy.test_topics.count, 0
+    assert_equal dummy.test_topic_names, []
+    assert_equal dummy.test_topic_uris, []
+  end
+
+  test 'can create an attribute with terms from multiple ontologies' do
+    dummy = materials(:good_material).becomes(DummyMaterial)
+
+    # This is found in both ontologies ...
+    dummy.multi_test_topic_names = ['Bioinformatics']
+    dummy.save!
+    assert_equal dummy.multi_test_topics.count, 2
+    assert_equal Set.new(dummy.multi_test_topic_uris),
+                 Set.new(['http://edamontology.org/topic_0091', 'http://dummy/Bioinformatics'])
+    # The two exact names collapse into one ...
+    assert_equal dummy.multi_test_topic_names, ['Bioinformatics']
+
+    # This is found in only in Edam ...
+    dummy.multi_test_topic_names = ['Biochemistry']
+    dummy.save!
+    assert_equal dummy.multi_test_topics.count, 1
+    assert_equal dummy.multi_test_topic_names, ['Biochemistry']
+    assert_equal dummy.multi_test_topic_uris, ['http://edamontology.org/topic_3292']
+
+    # This is found only in DummyOntology ...
+    dummy.multi_test_topic_names = ['Poodles']
+    dummy.save!
+    assert_equal dummy.multi_test_topics.count, 1
+    assert_equal dummy.multi_test_topic_names, ['Poodles']
+    assert_equal dummy.multi_test_topic_uris, ['http://dummy/Poodles']
+
+    # This is found in neither ...
+    dummy.multi_test_topic_names = ['Poodle Chemistry']
+    dummy.save!
+    assert_equal dummy.multi_test_topics.count, 0
+    assert_equal dummy.multi_test_topic_names, []
+    assert_equal dummy.multi_test_topic_uris, []
+
+    # Set via URIs
+    dummy.multi_test_topic_uris = ['http://dummy/Poodles',
+                                   'http://edamontology.org/topic_3292']
+    dummy.save!
+    assert_equal dummy.multi_test_topics.count, 2
+    assert_equal Set.new(dummy.multi_test_topic_names),
+                 Set.new(['Biochemistry', 'Poodles'])
+    assert_equal Set.new(dummy.multi_test_topic_uris),
+                 Set.new(['http://dummy/Poodles',
+                          'http://edamontology.org/topic_3292'])
+    assert_equal dummy.ontology_term_links.map(&:field), ["multi_test_topics",
+                                                          "multi_test_topics"]
+    assert_equal Set.new(dummy.ontology_term_links.map(&:term_uri)),
+                 Set.new(['http://dummy/Poodles',
+                          'http://edamontology.org/topic_3292'])
   end
 end


### PR DESCRIPTION
**Summary of changes**

This is a scheme to specify multiple ontologies for a field that is completely backwards compatible with the current single ontology implementation.

As before, we can specify an ontology like we do in the models:

```
has_ontology_terms(:scientific_topics, branch: EDAM.topics)
```
(This takes the default of `Edam::Ontology.instance` for the `ontology` argument.)

Now you could allow terms from more than one ontology, like in the tests in `test/unit/has_ontology_terms_test.rb`:

```
 has_ontology_terms(:test_topics, ontology: DummyOntology.instance)
 has_ontology_terms(:multi_test_topics,
                     ontologies: [{ ontology: Edam::Ontology.instance,
                                    branch: EDAM.topics},
                                  { ontology: DummyOntology.instance}])
```
The `ontologies` argument takes an array of hashes, each hash having keys `ontology` and `branch` (and if either key is excluded, it takes similar defaults as before).
In the example above, terms come from Edam (topics branch) and from DummyOntology (no branch specified).

**Motivation and context**

Explora uses multiple ontologies for scientific topics, and this implementation is adapted from that work. In the Explora case, we use a preferred ontology (CRDC from Statistics Canada) that we expose in the user interface (auto-complete), but we also want to be able to ingest Bioschemas that uses Edam.

Out of scope: this work does not address auto-complete in any controllers. The person implementing the ontology has to figure that one out themselves (in the Explora case, we basically did a `s/edam/crdc/` and renames `EdamController` to `CRDCController`.

**Screenshots**

Not much to screenshot, since this works at a very abstract level and in fact there are no concrete examples in the code base. The test to look at though is `test/unit/has_ontology_terms_test.rb`, which has examples of this working in a mocked sense.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree to license it to the TeSS codebase under the [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
