### PR TITLE
Fix jQuery version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -246,7 +246,7 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     jquery-qtip2-wrapper-rails (3.0.3)
-    jquery-rails (4.6.0)
+    jquery-rails (4.6.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,7 +10,7 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
-//= require jquery
+//= require jquery3
 //= require jquery.turbolinks
 //= require jquery_ujs
 //= require bootstrap-sprockets
@@ -79,8 +79,7 @@ const Index = {
 
 // Perform an ajax request to load the calendar and replace the contents
 window.loadCalendar = function(url) {
-    req = $.ajax(url);
-    req.done((res) => eval(res));
+    $.ajax(url, { dataType: 'script', cache: true }); // Is loaded automatically.
     return true;
 }
 

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -26,7 +26,7 @@
       <ul class="nav nav-xs nav-pills index-display-options">
         <%# We should consider setting the active status based on the query fragment so we can deeplink %>
         <%= tab('List', 'fa fa-list', 'home', active: true) %>
-        <%= tab('Calendar', 'fa fa-calendar', 'calendar', options: { 'data-calendar': calendar_events_path(search_and_facet_params.merge(format: :js, per_page: 200))}) %>
+        <%= tab('Calendar', 'fa fa-calendar', 'calendar', options: { 'data-calendar': calendar_events_path(search_and_facet_params.merge(per_page: 200))}) %>
         <% if TeSS::Config.map_enabled %>
           <%= tab('Map', 'fa fa-globe', 'map',
                   disabled: { check: (search_and_facet_params[:online] == 'true'),


### PR DESCRIPTION
**Summary of changes**

- Load jQuery 3.7.1 (from `jquery-rails`) instead of version 1.x.
- Fix JS eval error when loading calendar.
- Bump `jquery-rails` version

**Motivation and context**

Events calendar was not loading due to CSP violation caused by old jQuery trying to use `eval`.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree to license it to the TeSS codebase under the [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
