### PR TITLE
Fix general search bar not restricting to current space

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -13,6 +13,10 @@ class SearchController < ApplicationController
       search_models.each do |model_name|
         model = model_name.constantize
         @results[model_name.underscore.pluralize.to_sym] = Sunspot.search(model) do
+          if Facets.applicable?(:across_all_spaces, model)
+            Facets.across_all_spaces(self, false, current_user)
+          end
+
           fulltext search_params
 
           with('end').greater_than(Time.zone.now) if model_name == 'Event'

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -46,4 +46,63 @@ class SearchControllerTest < ActionController::TestCase
     end
   end
 
+  test 'should restrict searches to current space' do
+    plant_space = spaces(:plants)
+    # Dummy class that records which `with` constraints were used in the search
+    dummy_search = Class.new do
+      attr_reader :constraints
+
+      def initialize
+        @constraints = Hash.new(:unset)
+      end
+
+      def clear
+        @constraints.clear
+      end
+
+      def with(field, value = nil)
+        @constraints[field] = value
+        self
+      end
+
+      def method_missing(*args); self; end
+    end
+
+    search = dummy_search.new
+    Sunspot.stub(:search, -> (_, &block) { search.instance_eval(&block) }) do
+      # When not in a space, with spaces disabled, space constraint should be unset (show everything)
+      with_settings(solr_enabled: true, feature: { spaces: false }) do
+        get :index, params: { q: 'banana' }
+        assert_response :success
+        assert_equal :unset, search.constraints[:space_id]
+      end
+
+      search.clear
+      # When not in a space, with spaces enabled, space constraint should be nil (show things in default space)
+      with_settings(solr_enabled: true, feature: { spaces: true }) do
+        get :index, params: { q: 'banana' }
+        assert_response :success
+        assert_nil search.constraints[:space_id]
+      end
+
+      with_host(plant_space.host) do
+        search.clear
+        # When in a space, with spaces enabled, space constraint should be that space's ID (show things in that space)
+        with_settings(solr_enabled: true, feature: { spaces: true }) do
+          get :index, params: { q: 'banana' }
+          assert_response :success
+          assert_equal plant_space.id, search.constraints[:space_id]
+        end
+
+        search.clear
+        # When in a space, with spaces disabled, space constraint should be unset (show everything)
+        with_settings(solr_enabled: true, feature: { spaces: false }) do
+          get :index, params: { q: 'banana' }
+          assert_response :success
+          assert_equal :unset, search.constraints[:space_id]
+        end
+      end
+    end
+  end
+
 end

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -69,7 +69,7 @@ class SearchControllerTest < ActionController::TestCase
     end
 
     search = dummy_search.new
-    Sunspot.stub(:search, -> (_, &block) { search.instance_eval(&block) }) do
+    Sunspot.stub(:search, ->(_, &block) { search.instance_eval(&block); MockSearch.new([]) }) do
       # When not in a space, with spaces disabled, space constraint should be unset (show everything)
       with_settings(solr_enabled: true, feature: { spaces: false }) do
         get :index, params: { q: 'banana' }
@@ -104,5 +104,4 @@ class SearchControllerTest < ActionController::TestCase
       end
     end
   end
-
 end


### PR DESCRIPTION
**Summary of changes**

- Scopes the general search to the current space (if spaces enabled)

**Motivation and context**

It was returning results from all spaces.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree to license it to the TeSS codebase under the [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
