### PR TITLE
Add OAI-PMH subscribe button

### DIFF
--- a/app/views/subscriptions/_subscribe_button.html.erb
+++ b/app/views/subscriptions/_subscribe_button.html.erb
@@ -2,6 +2,7 @@
   show_email_sub = true
   show_calendar_sub = (type == 'Event')
   show_rss_sub = (type == 'Event')
+  show_oai_pmh_sub = (type == 'Material')
 %>
 
 <% if show_calendar_sub || show_email_sub || show_rss_sub %>
@@ -36,6 +37,13 @@
                 title="<%= t('subscriptions.button.events_rss_feed') %>" href="<%= rss_url %>" />
         <% end %>
       <% end %>
+      <% if show_oai_pmh_sub %>
+        <li>
+          <a href="#" data-toggle="modal" data-target="#subscribe-oai-pmh-modal">
+            <i class="fa fa-arrow-left"></i> <%= t('subscriptions.button.to_oai_pmh') %>
+          </a>
+        </li>
+      <% end %>
     </ul>
   </div>
 
@@ -68,4 +76,5 @@
 
   <%= render partial: 'subscriptions/subscribe_to_calendar_modal' if show_calendar_sub %>
   <%= render partial: 'subscriptions/subscribe_to_rss_modal', locals: { url: rss_url } if show_rss_sub %>
+  <%= render partial: 'subscriptions/subscribe_to_oai_pmh_modal', locals: { url: oai_pmh_url } if show_oai_pmh_sub %>
 <% end %>

--- a/app/views/subscriptions/_subscribe_to_oai_pmh_modal.html.erb
+++ b/app/views/subscriptions/_subscribe_to_oai_pmh_modal.html.erb
@@ -1,0 +1,29 @@
+<div class="modal fade" tabindex="-1" role="dialog" aria-labelledby="subscribe-oai-pmh-modal-title" id="subscribe-oai-pmh-modal">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal"
+                aria-label="<%= t('subscriptions.modal.close') %>">
+          <span aria-hidden="true">&times;</span></button>
+        <h4 class="modal-title" id="subscribe-oai-pmh-modal-title">
+          <%= t('subscriptions.button.to_oai_pmh') %>
+        </h4>
+      </div>
+
+      <div class="modal-body">
+        <label for="oai-pmh-link"><%= t('subscriptions.modal.url') %></label>
+        <div class="input-group input-group-lg">
+          <input id="oai-pmh-link" type="text" class="form-control" value="<%= url %>" readonly>
+          <span class="input-group-btn">
+            <button class="btn btn-default clipboard-btn" type="button" data-clipboard-target="#oai-pmh-link"
+                    title="<%= t('subscriptions.modal.click_to_copy') %>">
+              <i class="fa fa-clipboard" aria-hidden="true"></i>
+            </button>
+          </span>
+        </div>
+        <h3><%= t('subscriptions.oai_pmh.instructions_header') %></h3>
+        <p><%= t('subscriptions.oai_pmh.instructions_body_html', url: url) %></p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/subscriptions/_subscribe_to_oai_pmh_modal.html.erb
+++ b/app/views/subscriptions/_subscribe_to_oai_pmh_modal.html.erb
@@ -22,7 +22,7 @@
           </span>
         </div>
         <h3><%= t('subscriptions.oai_pmh.instructions_header') %></h3>
-        <p><%= t('subscriptions.oai_pmh.instructions_body_html', url: url) %></p>
+        <p><%= t('subscriptions.oai_pmh.instructions_body_html') %></p>
       </div>
     </div>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1012,6 +1012,7 @@ en:
       via_email: 'Subscribe via email'
       add_to_calendar: 'Add to calendar'
       to_rss: 'Subscribe to RSS feed'
+      to_oai_pmh: 'Harvest using OAI-PMH'
       events_rss_feed: 'Events RSS feed'
       email_title: 'Email Subscription'
       submit_button: 'Subscribe'
@@ -1042,6 +1043,14 @@ en:
       instructions_paragraph2_html: >-
         Please note, it may take a while for newly created events in %{title} to synchronise with
         your Google Calendar.
+    oai_pmh:
+      instructions_header: 'Exchange content using OAI-PMH'
+      instructions_body_html: >-
+        Use an <a href="https://www.openarchives.org/pmh/" target="_blank" rel="noopener">OAI-PMH</a> compatible 
+        tool to harvest metadata using the OAI-PMH endpoint. In particular, this endpoint 
+        can be used for exchanging content between different TeSS instances. 
+        See the <a href="https://elixirtess.github.io/docs/" target="_blank" rel="noopener">TeSS documentation</a> 
+        for more details.
     unsubscribe:
       success: 'You have successfully unsubscribed.'
     frequency_options:


### PR DESCRIPTION
**Summary of changes**

- Added OAI-PMH subscribe button and modal with minimal explanation and OAI-PMH link

**Motivation and context**

Closes #1316 

**Screenshots**

<img width="752" height="377" alt="image" src="https://github.com/user-attachments/assets/c320a310-1f59-4dda-9981-a364155d2aa1" />

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree to license it to the TeSS codebase under the [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
