### PR TITLE
Adminer docker compose dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,8 @@ services:
     volumes:
       - db-data:/var/lib/postgresql/data
   adminer:
-    image: adminer
+    container_name: ${PREFIX}-adminer
+    image: adminer:5.4.2
     restart: always
     ports:
       - 8080:8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,9 +40,9 @@ services:
   adminer:
     container_name: ${PREFIX}-adminer
     image: adminer:5.4.2
-    restart: always
+    restart: unless-stopped
     ports:
-      - 8080:8080
+      - '127.0.0.1:8080:8080'
     depends_on:
       - db
   solr:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,8 @@ services:
     restart: always
     ports:
       - 8080:8080
+    depends_on:
+      - db
   solr:
     container_name: ${PREFIX}-solr
     image: solr:8

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,11 @@ services:
       interval: 5s
     volumes:
       - db-data:/var/lib/postgresql/data
+  adminer:
+    image: adminer
+    restart: always
+    ports:
+      - 8080:8080
   solr:
     container_name: ${PREFIX}-solr
     image: solr:8

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -65,7 +65,7 @@ An Adminer instance to connect to and visualize your local database is accessibl
 
 <http://localhost:8080>
 
-Credentials are in the .env file (choose PostgreSQL for "System").
+Credentials are in the `.env` file. Use `db` as the server/host (choose PostgreSQL for "System").
 
 ### Testing
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -59,10 +59,9 @@ TeSS is accessible at the following URL:
 
 <http://localhost:3000>
 
+### Access [Adminer](https://www.adminer.org/)
 
-### Access Adminer
-
-An Adminer instance is accessible at the following URL:
+An Adminer instance to connect to and visualize your local database is accessible at the following URL:
 
 <http://localhost:8080>
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -59,6 +59,15 @@ TeSS is accessible at the following URL:
 
 <http://localhost:3000>
 
+
+### Access Adminer
+
+An Adminer instance is accessible at the following URL:
+
+<http://localhost:8080>
+
+Credentials are in the .env file (choose PostgreSQL for "System").
+
 ### Testing
 
 The full test suite can be run using the following command:


### PR DESCRIPTION
**Summary of changes**

- PostgreSQL DB was not accessible by the host in Docker development mode (no binding with host port)
- Added an Adminer instance on port 8080 to facilitate DB management/observations

**Motivation and context**
- No possibility of having access to the database using Docker in development.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree to license it to the TeSS codebase under the [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
