### PR TITLE
doc: add port information for using spaces on Docker instance

### DIFF
--- a/docs/spaces.md
+++ b/docs/spaces.md
@@ -24,6 +24,8 @@ file `config/initializers/local_hosts.rb` and add the necessary hosts to Rails' 
 Rails.application.config.hosts << '.mytess.training' if Rails.env.development?
 ```
 
+if you are using Docker, the private space is accessible on port 3000 (e.g.: http://whatever.mytess.training:3000)
+
 # Production
 
 To run a multi-space TeSS instance in production you will need to:


### PR DESCRIPTION
**Summary of changes**

- Adding info for using Spaces on a Docker instance.

**Motivation and context**

- When using Docker, Spaces are running on port 3000 like the global TeSS app. This was not specified in the Spaces URL setup doc.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree to license it to the TeSS codebase under the [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
