### PR TITLE
fix(docker-compose): update to redis:7

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -58,7 +58,7 @@ services:
       - /opt/solr/server/solr/configsets/production
   redis:
     container_name: ${PREFIX}-redis
-    image: redis:6
+    image: redis:7
     restart: always
     healthcheck:
       test: redis-cli ping

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
       - '8984:8983'
   redis:
     container_name: ${PREFIX}-redis
-    image: redis:6
+    image: redis:7
     healthcheck:
       test: redis-cli ping
       interval: 1s


### PR DESCRIPTION
**Summary of changes**

Upgrading redis in `docker-compose.yml` to version 7 as the latest gem/ruby/ror made some of the gems only compatible with version 7 of redis

**Motivation and context**

Tests weren't passing under redis:6

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree to license it to the TeSS codebase under the [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
