### PR TITLE
Show space title in head. Fixes #1329

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -441,7 +441,7 @@ module ApplicationHelper
     else
       ''
       # end + "TeSS (Training eSupport System)"
-    end + TeSS::Config.site['title']
+    end + (Space.current_space.default? ? TeSS::Config.site['title'] : Space.current_space.title)
   end
 
   # Renders a title on the page (by default in an H2 tag, pass a "tag" option with a symbol to change) as well as

--- a/test/controllers/static_controller_test.rb
+++ b/test/controllers/static_controller_test.rb
@@ -800,4 +800,17 @@ class StaticControllerTest < ActionController::TestCase
       end
     end
   end
+
+  test 'shows space title in head when looking at a space' do
+    space = spaces(:plants)
+    with_host(space.host) do
+      get :home
+      assert_select 'head title', text: 'TeSS Plants Community'
+    end
+  end
+
+  test 'shows regular title in head when in default space' do
+    get :home
+    assert_select 'head title', text: 'TeSS Test Instance'
+  end
 end


### PR DESCRIPTION
**Summary of changes**

- Ensure tab/window title reflects current space

**Motivation and context**

#1329

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree to license it to the TeSS codebase under the [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
