### PR TITLE
Separate "audit" workflow

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -12,7 +12,7 @@ on:
       timezone: 'Europe/London'
 
 jobs:
-  test:
+  audit:
     runs-on: ubuntu-latest
     steps:
       - name: Install system dependencies

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,20 @@
+name: Gem audit
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install imagemagick
+      - name: Check out code
+        uses: actions/checkout@v6
+      - name: Install Ruby & gems
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: Audit gems
+        run: bundle exec bundle-audit check --update

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,6 +1,15 @@
 name: Gem audit
 
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - 'Gemfile*'
+  pull_request:
+    paths:
+      - 'Gemfile*'
+  schedule:
+    - cron: '0 9 * * 1'
+      timezone: 'Europe/London'
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,5 +64,3 @@ jobs:
         run: bundle exec rails test
       - name: Run system tests
         run: bundle exec rails test:system
-      - name: Audit gems
-        run: bundle exec bundle-audit check --update

--- a/Gemfile
+++ b/Gemfile
@@ -91,7 +91,6 @@ group :development do
   gem 'web-console'
 end
 
-
 group :test do
   gem 'capybara'
   gem 'committee'

--- a/Gemfile
+++ b/Gemfile
@@ -91,6 +91,7 @@ group :development do
   gem 'web-console'
 end
 
+
 group :test do
   gem 'capybara'
   gem 'committee'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -943,6 +943,5 @@ DEPENDENCIES
   whenever
   will_paginate
 
-
 BUNDLED WITH
   4.0.13

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,7 +179,7 @@ GEM
       countries (~> 5.0)
     crack (0.4.5)
       rexml
-    crass (1.0.6)
+    crass (1.0.7)
     csv (3.3.2)
     date (3.5.1)
     debug_inspector (1.1.0)
@@ -392,7 +392,7 @@ GEM
       monetize (~> 1.9)
       money (~> 6.13)
       railties (>= 3.0)
-    msgpack (1.7.2)
+    msgpack (1.8.3)
     multi_json (1.19.1)
     multi_xml (0.8.0)
       bigdecimal (>= 3.1, < 5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -943,5 +943,6 @@ DEPENDENCIES
   whenever
   will_paginate
 
+
 BUNDLED WITH
   4.0.13


### PR DESCRIPTION
**Summary of changes**

- Move gem auditing into separate workflow which only runs if Gemfile/Gemfile.lock was modified.
- Also run it automatically on Monday @ 9AM - but possibly this is unnecessary with dependabot... remove if it is just flagging duplicate issues.

**Motivation and context**

It was annoying having the test workflow "fail" due to no fault of the committed code.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree to license it to the TeSS codebase under the [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).

(Squash before merge)