### PR TITLE
feat(featured_trainer): choose how many trainers to feature

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -38,7 +38,7 @@ class StaticController < ApplicationController
     trainers = Trainer.joins(:user).order(:id)
     f_trainers = trainers.where.not(users: { image_file_size: nil })
     trainers = f_trainers.exists? ? f_trainers : trainers
-    trainers.sample(1)
+    trainers.sample(TeSS::Config.site.dig('home_page', 'featured_trainer'))
   end
 
   def set_content_providers

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -32,13 +32,22 @@ class StaticController < ApplicationController
   end
 
   def set_featured_trainer
-    return nil unless TeSS::Config.site.dig('home_page', 'featured_trainer')
+    featured_trainer = TeSS::Config.site.dig('home_page', 'featured_trainer')
+    return nil if featured_trainer.blank? || featured_trainer == false
 
+    # featured_trainers used to be boolean, we keep this safety net for TeSS instances using the legacy value
+    # https://github.com/ElixirTeSS/TeSS/pull/1340
+    n_trainers = case featured_trainer
+                 when true then 1
+                 else [featured_trainer.to_i, 0].max
+                 end
+    return nil if n_trainers.zero?
+    
     srand(Date.today.beginning_of_day.to_i)
     trainers = Trainer.joins(:user).order(:id)
     f_trainers = trainers.where.not(users: { image_file_size: nil })
     trainers = f_trainers.exists? ? f_trainers : trainers
-    trainers.sample(TeSS::Config.site.dig('home_page', 'featured_trainer'))
+    trainers.sample(n_trainers)
   end
 
   def set_content_providers

--- a/config/tess.example.yml
+++ b/config/tess.example.yml
@@ -109,7 +109,7 @@ default: &default
       promo_blocks: false
       upcoming_events: # Number of events on home page. Leave blank to turn off
       latest_materials: # Number of materials on home page. Leave blank to turn off
-      featured_trainer: false
+      featured_trainer: # Number of trainers to feature on home page. Leave blank to turn off
       counters: false # Whether or not to show number of database objects in separate blocks
       search_box: true # Whether or not to show the search box
       additional_links: # Add custom links in separate blocks

--- a/test/controllers/static_controller_test.rb
+++ b/test/controllers/static_controller_test.rb
@@ -312,11 +312,20 @@ class StaticControllerTest < ActionController::TestCase
   end
 
   test 'should show featured trainer' do
-    with_settings({ site: { home_page: { featured_trainer: true } } }) do
+    with_settings({ site: { home_page: { featured_trainer: 2 } } }) do
       get :home
       assert_select 'section#featured_trainer', count: 1
       assert_select 'section#featured_trainer h2', count: 1
-      assert_select 'section#featured_trainer li', count: 1
+      assert_select 'section#featured_trainer li', count: 2
+    end
+  end
+
+  test 'should not show featured trainer' do
+    with_settings({ site: { home_page: { featured_trainer: nil } } }) do
+      get :home
+      assert_select 'section#featured_trainer', count: 0
+      assert_select 'section#featured_trainer h2', count: 0
+      assert_select 'section#featured_trainer li', count: 0
     end
   end
 

--- a/test/controllers/static_controller_test.rb
+++ b/test/controllers/static_controller_test.rb
@@ -311,7 +311,25 @@ class StaticControllerTest < ActionController::TestCase
     end
   end
 
-  test 'should show featured trainer' do
+  test 'should show featured trainer (legacy boolean value set to `true`)' do
+    with_settings({ site: { home_page: { featured_trainer: true } } }) do
+      get :home
+      assert_select 'section#featured_trainer', count: 1
+      assert_select 'section#featured_trainer h2', count: 1
+      assert_select 'section#featured_trainer li', count: 1
+    end
+  end
+
+  test 'should not show featured trainer (legacy boolean value set to `false`)' do
+    with_settings({ site: { home_page: { featured_trainer: false } } }) do
+      get :home
+      assert_select 'section#featured_trainer', count: 0
+      assert_select 'section#featured_trainer h2', count: 0
+      assert_select 'section#featured_trainer li', count: 0
+    end
+  end
+
+  test 'should show featured trainer (positive int case)' do
     with_settings({ site: { home_page: { featured_trainer: 2 } } }) do
       get :home
       assert_select 'section#featured_trainer', count: 1
@@ -320,7 +338,7 @@ class StaticControllerTest < ActionController::TestCase
     end
   end
 
-  test 'should not show featured trainer' do
+  test 'should not show featured trainer (nil case)' do
     with_settings({ site: { home_page: { featured_trainer: nil } } }) do
       get :home
       assert_select 'section#featured_trainer', count: 0


### PR DESCRIPTION
**Summary of changes**

- We can now choose how many trainers we want to feature in the home page

**Motivation and context**

The value `1` was hardcoded, I wanted more

**Screenshots**

N/A

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree to license it to the TeSS codebase under the [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
