### PR TITLE
Move source test results location

### DIFF
--- a/app/models/concerns/has_test_job.rb
+++ b/app/models/concerns/has_test_job.rb
@@ -53,7 +53,7 @@ module HasTestJob
 
   def test_results_path
     path_id = Rails.env.test? ? "fakeid_#{model_name.singular}_#{id}" : test_job_id
-    File.join(Rails.root, 'tmp', "test_results_#{path_id}.yml")
+    Rails.root.join('tmp', 'source_test_results').tap { |d| d.mkdir unless d.exist? }.join("test_results_#{path_id}.yml")
   end
 
   def deep_hashify(params)

--- a/app/models/concerns/has_test_job.rb
+++ b/app/models/concerns/has_test_job.rb
@@ -53,7 +53,9 @@ module HasTestJob
 
   def test_results_path
     path_id = Rails.env.test? ? "fakeid_#{model_name.singular}_#{id}" : test_job_id
-    Rails.root.join('tmp', 'source_test_results').tap { |d| d.mkdir unless d.exist? }.join("test_results_#{path_id}.yml")
+    dir = Rails.root.join('tmp', 'source_test_results')
+    dir.mkpath
+    dir.join("test_results_#{path_id}.yml")
   end
 
   def deep_hashify(params)


### PR DESCRIPTION
**Summary of changes**

- Moves them into a directory under `tmp` instead of in there directly.

**Motivation and context**

In a deployment where 2 app instances are sharing DB/storage, one instance could not access test results run on the other. After this change it is possible via symlinks.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree to license it to the TeSS codebase under the [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
