### PR TITLE
Adding `%{repository}` instead of hardcoded GitHub repo in `en.yml`

### DIFF
--- a/config/initializers/i18n_defaults.rb
+++ b/config/initializers/i18n_defaults.rb
@@ -3,7 +3,8 @@ module I18n
     alias original_translate translate
 
     def translate(key, **options)
-      defaults = { site_name: TeSS::Config.site['title_short'] }
+      defaults = { site_name: TeSS::Config.site['title_short'],
+                    repository: TeSS::Config.site['repository'] }
       original_translate(key, **defaults.merge(options))
     end
     alias t translate

--- a/config/initializers/i18n_defaults.rb
+++ b/config/initializers/i18n_defaults.rb
@@ -4,7 +4,8 @@ module I18n
 
     def translate(key, **options)
       defaults = { site_name: TeSS::Config.site['title_short'],
-                    repository: TeSS::Config.site['repository'] }
+                    repository: TeSS::Config.site['repository'],
+                    data_license: TeSS::Config.site['data_license'] }
       original_translate(key, **defaults.merge(options))
     end
     alias t translate

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -187,11 +187,11 @@ en:
       As such, all content in %{site_name} is available under the CC BY 4.0 licence, and can be accessed through our API
       and widgets. The %{site_name} codebase is also available to re-use under the BSD Licence, and can be found on GitHub.
     code_license: >
-      <a href="https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE", target="_blank">BSD 3-Clause<i class="icon icon-md arrow-top-right-icon"></i></a>
+      <a href="%{repository}/blob/master/LICENSE", target="_blank">BSD 3-Clause<i class="icon icon-md arrow-top-right-icon"></i></a>
     data_license: >
       <a href="https://creativecommons.org/licenses/by/4.0/", target="_blank">CC-BY 4.0<i class="icon icon-md arrow-top-right-icon"></i></a>
     contributions: >
-      <a href="https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md", target="_blank">contributions<i class="icon icon-md arrow-top-right-icon"></i></a>
+      <a href="%{repository}/blob/master/CONTRIBUTING.md", target="_blank">contributions<i class="icon icon-md arrow-top-right-icon"></i></a>
     gmaps_countries: >
       'United Kingdom', 'Spain', 'Portugal', 'France', 'Belgium', 'Ireland', 'Estonia', 'Finland',
       'Germany', 'Austria', 'Italy', 'Hungary', 'Czech Republic', 'Estonia', 'Denmark',

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -186,12 +186,12 @@ en:
       %{site_name} is committed to the FAIR principles: making data findable, accessible, interoperable and re-usable.
       As such, all content in %{site_name} is available under the CC BY 4.0 licence, and can be accessed through our API
       and widgets. The %{site_name} codebase is also available to re-use under the BSD Licence, and can be found on GitHub.
-    code_license: >
-      <a href="%{repository}/blob/master/LICENSE", target="_blank">BSD 3-Clause<i class="icon icon-md arrow-top-right-icon"></i></a>
+    code_license: > # IT MUST STAY BSD 3-Clause LICENSE FOR EVERY TESS INSTANCE
+      <a href="%{repository}/blob/master/LICENSE" target="_blank" rel="noopener noreferrer">BSD 3-Clause<i class="icon icon-md arrow-top-right-icon"></i></a>
     data_license: >
-      <a href="https://creativecommons.org/licenses/by/4.0/", target="_blank">CC-BY 4.0<i class="icon icon-md arrow-top-right-icon"></i></a>
+      <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" rel="noopener noreferrer">%{data_license}<i class="icon icon-md arrow-top-right-icon"></i></a>
     contributions: >
-      <a href="%{repository}/blob/master/CONTRIBUTING.md", target="_blank">contributions<i class="icon icon-md arrow-top-right-icon"></i></a>
+      <a href="%{repository}/blob/master/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer">contributions<i class="icon icon-md arrow-top-right-icon"></i></a>
     gmaps_countries: >
       'United Kingdom', 'Spain', 'Portugal', 'France', 'Belgium', 'Ireland', 'Estonia', 'Finland',
       'Germany', 'Austria', 'Italy', 'Hungary', 'Czech Republic', 'Estonia', 'Denmark',

--- a/config/tess.example.yml
+++ b/config/tess.example.yml
@@ -97,6 +97,7 @@ default: &default
     logo_email: ''
     default_theme: default
     repository: 'https://github.com/ElixirTeSS/TeSS'
+    data_license: 'CC-BY 4.0'
     supported_by: 'elixir_supported_by'
     widget_example:
     home_page: # Configuration for the sections displayed on the front page


### PR DESCRIPTION
**Summary of changes**

- This is a quick one: I have created a `%{repository}` to not have a hardcoded URL in `en.yml`

**Motivation and context**

As I will now have different repos for HEP Training and EVERSE Training, I needed the URLs to be interchangeable easily.

**Screenshots**

N/A

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree to license it to the TeSS codebase under the [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
