### PR TITLE
Space indication on index + show pages

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -138,7 +138,6 @@ div.wrapper {
 
 #content {
   flex-grow: 1;
-  overflow: hidden;
 }
 
 #sidebar {

--- a/app/helpers/spaces_helper.rb
+++ b/app/helpers/spaces_helper.rb
@@ -4,6 +4,14 @@ module SpacesHelper
     I18n.t('info.spaces.description')
   end
 
+  def space_tag(resource)
+    if TeSS::Config.feature['spaces'] && resource.space && !resource.space.default? && resource.space != current_space
+      content_tag(:span, class: 'label label-info space-tag', style: 'position: absolute; right: -5px; top: -5px;') do
+        content_tag(:i, '', class: 'fa fa-share-square') + ' ' + resource.space.title
+      end
+    end
+  end
+
   def space_feature_options
     Space::FEATURES.select do |f|
       TeSS::Config.feature[f]

--- a/app/views/collections/_collection.html.erb
+++ b/app/views/collections/_collection.html.erb
@@ -1,4 +1,5 @@
 <li class="masonry-brick media-item long">
+  <%= space_tag(collection) %>
   <%= link_to collection, class: 'link-overlay' do %>
     <h4><%= title_with_privacy(collection) %></h4>
 

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -1,5 +1,6 @@
 <div class="wrapper collapsing-wrapper">
   <div class="collapsing-sidebar" id="sidebar">
+    <%= render partial: 'common/space_info', locals: { resource: @collection } %>
     <%= render partial: 'collections/partials/collection_info', locals: { collection: @collection } %>
   </div>
 

--- a/app/views/common/_space_info.erb
+++ b/app/views/common/_space_info.erb
@@ -1,0 +1,18 @@
+<% space = resource.space %>
+<% if TeSS::Config.feature['spaces'] && space && !space.default? && space != current_space %>
+  <% theme_colour = TeSS::Config.themes[space.theme]&.dig('primary') %>
+  <h4 class="nav-heading"><%= Space.model_name.human %></h4>
+  <div class="nav-block" id="space-info">
+    <p>
+      <%= link_to(image_tag(get_image_url_for(space), class: 'medium-avatar', style: (theme_colour ? "background-color: #{theme_colour}" : nil)), space.url, target: :_blank) %>
+    </p>
+
+    <p>
+      <%= link_to space.title, space.url, class: 'h5', target: :_blank %>
+    </p>
+
+    <p>
+      <%= external_link_button t('other_space.link'), polymorphic_url(resource, host: space.host) %>
+    </p>
+  </div>
+<% end %>

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -1,6 +1,7 @@
 <% learning_path_topic_item ||= nil %>
 <% collection_item ||= learning_path_topic_item %>
 <li class="masonry-brick media-item long">
+  <%= space_tag(event) %>
   <%= link_to event, class: 'link-overlay with-left-icon' do %>
     <%= item_order_badge(collection_item) if collection_item %>
     <div class="with-left-icon">

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -2,6 +2,7 @@
   <%# SIDEBAR %>
   <div class="collapsing-sidebar" id="sidebar">
     <%= render partial: 'common/origin_info', locals: { resource: @event } %>
+    <%= render partial: 'common/space_info', locals: { resource: @event } %>
     <%= render partial: 'content_providers/partials/content_provider_info', locals: { content_provider: @event.content_provider } %>
     <%= render partial: "nodes/partials/associated_node_info", locals: { associated_nodes: @event.associated_nodes } %>
     <%= render(partial: 'users/partials/user_info', locals: { user: @event.user }) if current_user.try(:is_admin?) %>

--- a/app/views/learning_path_topics/_learning_path_topic.html.erb
+++ b/app/views/learning_path_topics/_learning_path_topic.html.erb
@@ -1,4 +1,5 @@
 <li class="masonry-brick media-item long">
+  <%= space_tag(learning_path_topic) %>
   <%= link_to learning_path_topic, class: 'link-overlay' do %>
     <div class="masonry-brick-heading">
         <h4><%= learning_path_topic.title %></h4>

--- a/app/views/learning_path_topics/show.html.erb
+++ b/app/views/learning_path_topics/show.html.erb
@@ -1,5 +1,6 @@
 <div class="wrapper collapsing-wrapper">
   <div class="collapsing-sidebar" id="sidebar">
+    <%= render partial: 'common/space_info', locals: { resource: @learning_path_topic } %>
     <h4 class="nav-heading"><%= LearningPathTopic.model_name.human %></h4>
     <div class="nav-block">
       <h5>

--- a/app/views/learning_paths/_learning_path.html.erb
+++ b/app/views/learning_paths/_learning_path.html.erb
@@ -1,5 +1,6 @@
 <% cache(learning_path, expires_in: 1.hour) do %>
   <li class="masonry-brick media-item large block-item learning-path-bg-<%= (learning_path.id % 4) + 1 -%>">
+    <%= space_tag(learning_path) %>
     <%= link_to learning_path, class: 'link-overlay' do %>
       <%= item_order_badge(collection_item) if defined? collection_item %>
 

--- a/app/views/learning_paths/_learning_path.html.erb
+++ b/app/views/learning_paths/_learning_path.html.erb
@@ -1,6 +1,6 @@
-<% cache(learning_path, expires_in: 1.hour) do %>
-  <li class="masonry-brick media-item large block-item learning-path-bg-<%= (learning_path.id % 4) + 1 -%>">
-    <%= space_tag(learning_path) %>
+<li class="masonry-brick media-item large block-item learning-path-bg-<%= (learning_path.id % 4) + 1 -%>">
+  <%= space_tag(learning_path) %>
+  <% cache(learning_path, expires_in: 1.hour) do %>
     <%= link_to learning_path, class: 'link-overlay' do %>
       <%= item_order_badge(collection_item) if defined? collection_item %>
 
@@ -41,6 +41,6 @@
 
       <%= item_comment(collection_item) if defined? collection_item %>
     <% end %>
-  </li>
-<% end %>
+  <% end %>
+</li>
 

--- a/app/views/learning_paths/show.html.erb
+++ b/app/views/learning_paths/show.html.erb
@@ -1,5 +1,6 @@
 <div class="wrapper collapsing-wrapper">
   <div class="collapsing-sidebar" id="sidebar">
+    <%= render partial: 'common/space_info', locals: { resource: @learning_path } %>
     <%= render partial: 'content_providers/partials/content_provider_info', locals: { content_provider: @learning_path.content_provider } %>
     <%= render partial: 'nodes/partials/associated_node_info', locals: { associated_nodes: @learning_path.associated_nodes } %>
     <%= render(partial: 'users/partials/user_info', locals: { user: @learning_path.user }) if current_user.try(:is_admin?) %>

--- a/app/views/materials/_material.html.erb
+++ b/app/views/materials/_material.html.erb
@@ -7,6 +7,7 @@
   end
 %>
 <li class="masonry-brick media-item long">
+  <%= space_tag(material) %>
   <%= link_to material_path(material, **link_params), class: 'link-overlay' do %>
     <%= item_order_badge(collection_item) if show_order && collection_item %>
 

--- a/app/views/materials/show.html.erb
+++ b/app/views/materials/show.html.erb
@@ -4,6 +4,7 @@
                locals: { topic_link: @learning_path_topic_link,
                          topic_item: @learning_path_topic_item } if @learning_path_topic_link && @learning_path_topic_item %>
     <%= render partial: 'common/origin_info', locals: { resource: @material } %>
+    <%= render partial: 'common/space_info', locals: { resource: @material } %>
     <%= render partial: 'content_providers/partials/content_provider_info', locals: { content_provider: @material.content_provider } %>
     <%= render partial: 'nodes/partials/associated_node_info', locals: { associated_nodes: @material.associated_nodes } %>
     <%= render(partial: 'users/partials/user_info', locals: { user: @material.user }) if current_user.try(:is_admin?) %>

--- a/app/views/sources/_source.html.erb
+++ b/app/views/sources/_source.html.erb
@@ -1,4 +1,5 @@
 <div class="masonry-brick media-item long">
+  <%= space_tag(source) %>
   <%= link_to source, class: 'link-overlay' do %>
     <h4>
       <%= source.title %>

--- a/app/views/sources/show.html.erb
+++ b/app/views/sources/show.html.erb
@@ -2,6 +2,7 @@
 
   <%# SIDEBAR %>
   <div class="collapsing-sidebar" id="sidebar">
+    <%= render partial: 'common/space_info', locals: { resource: @source } %>
     <%= render partial: "content_providers/partials/content_provider_info",
                locals: { content_provider: @source.content_provider } %>
   </div>

--- a/app/views/workflows/_workflow.html.erb
+++ b/app/views/workflows/_workflow.html.erb
@@ -1,4 +1,5 @@
 <li class="masonry-brick media-item long">
+  <%= space_tag(workflow) %>
   <%= link_to workflow, class: 'link-overlay' do %>
     <div class="masonry-brick-heading">
       <div class="masonry-icons">

--- a/app/views/workflows/show.html.erb
+++ b/app/views/workflows/show.html.erb
@@ -27,6 +27,13 @@
           <p class="muted">No description provided</p>
         <% end %>
         <%= render partial: 'common/extra_metadata', locals: { resource: @workflow } %>
+        <% space = @workflow.space %>
+        <% if TeSS::Config.feature['spaces'] && space && !space.default? && space != current_space %>
+          <p class="space no-spacing">
+            <strong class="text-primary"><%= Space.model_name.human %>: </strong>
+            <%= link_to(space.title, space) %>
+          </p>
+        <% end %>
         <% if policy(@workflow).update? && @workflow.edit_suggestion %>
           <%= render partial: 'common/approve_term_suggestions', locals: { suggestion: @workflow.edit_suggestion } %>
         <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1193,3 +1193,5 @@ en:
     title: Original entry
     info: "This %{resource_type} originated from another TeSS registry. For complete, up-to-date information, please visit the original entry:"
     link: Go to original entry
+  other_space:
+    link: View in space

--- a/test/controllers/materials_controller_test.rb
+++ b/test/controllers/materials_controller_test.rb
@@ -1721,4 +1721,46 @@ class MaterialsControllerTest < ActionController::TestCase
 
     assert_select '#origin-info a[href=?]', uri
   end
+
+  # Space info tests
+  test 'should show space info when viewing a material from a different non-default space' do
+    plant_space_material = materials(:plant_space_material)
+    with_settings(feature: { spaces: true }) do
+      # Request comes from the default space (no specific host)
+      get :show, params: { id: plant_space_material }
+      assert_response :success
+      assert_select '#space-info', count: 1
+      assert_select '#space-info a', text: plant_space_material.space.title
+    end
+  end
+
+  test 'should not show space info when viewing a material from the current space' do
+    plant_space = spaces(:plants)
+    plant_space_material = materials(:plant_space_material)
+    with_settings(feature: { spaces: true }) do
+      with_host(plant_space.host) do
+        get :show, params: { id: plant_space_material }
+        assert_response :success
+        assert_select '#space-info', count: 0
+      end
+    end
+  end
+
+  test 'should not show space info when spaces feature is disabled' do
+    plant_space_material = materials(:plant_space_material)
+    with_settings(feature: { spaces: false }) do
+      get :show, params: { id: plant_space_material }
+      assert_response :success
+      assert_select '#space-info', count: 0
+    end
+  end
+
+  test 'should not show space info when material has no space' do
+    with_settings(feature: { spaces: true }) do
+      # @material has no space assigned
+      get :show, params: { id: @material }
+      assert_response :success
+      assert_select '#space-info', count: 0
+    end
+  end
 end


### PR DESCRIPTION
**Summary of changes**

- Add a label on index pages to resources from a space that is not the current/default space.
- Add space info to the sidebar on show pages when viewing resources from another space, with a link to go to the resource in its "home" space.

**Motivation and context**

Was not clear where resources were coming from when searching across all spaces.

**Screenshots**

<img width="665" height="250" alt="image" src="https://github.com/user-attachments/assets/85a0adcd-b696-4e80-815f-f6ca140f13eb" />

<img width="347" height="272" alt="image" src="https://github.com/user-attachments/assets/09637db0-5b74-430c-8fa2-98758c4a881d" />


**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree to license it to the TeSS codebase under the [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
