### PR TITLE
Potentially fix system tests where content could not be found on page

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -4,5 +4,6 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400] do |options|
     options.add_argument('--no-sandbox')
     options.add_argument('--disable-dev-shm-usage')
+    options.add_argument('--disable-features=DeferRendererTasksAfterInput')
   end
 end


### PR DESCRIPTION
**Summary of changes**

- Disables some Chrome feature (`DeferRendererTasksAfterInput`) that was possibly causing it. 

**Motivation and context**

Error was:
```

Error:
GroupsTest#test_should_update_Group:
Selenium::WebDriver::Error::UnknownError: unknown error: unhandled inspector error: {"code":-32000,"message":"Node with given id does not belong to the document"}
  (Session info: chrome=151.0.7922.108)
    test/system/groups_test.rb:40:in 'block in <class:GroupsTest>'
..
```
<https://github.com/ElixirTeSS/TeSS/actions/runs/31781210426/job/94707172901#step:10:44>

Even though the text appears as normal in the screenshot:
<img width="1400" height="1257" alt="failures_test_should_update_Group" src="https://github.com/user-attachments/assets/91e1cf81-1440-4407-ad16-790e2880465a" />

Some discussion: <https://github.com/teamcapybara/capybara/issues/2800>

If it doesn't work, also try passing `--disable-backgrounding-occluded-windows`

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree to license it to the TeSS codebase under the [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
